### PR TITLE
Show a toast when the selected Location-Provider is disabled

### DIFF
--- a/app/src/main/java/org/blitzortung/android/location/LocationHandler.java
+++ b/app/src/main/java/org/blitzortung/android/location/LocationHandler.java
@@ -186,6 +186,13 @@ public class LocationHandler implements SharedPreferences.OnSharedPreferenceChan
                 toast.show();
                 return;
             }
+
+            if(!locationManager.isProviderEnabled(newProvider.getType())) {
+                Toast toast = Toast.makeText(context, String.format(context.getResources().getText(R.string.location_provider_disabled).toString(), newProvider.toString()), 5000);
+                toast.show();
+                return;
+            }
+
             final int minTime = backgroundMode
                     ? 120000
                     : (

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -310,4 +310,5 @@
     <string name="alarm_audio_signal_summary">Auswahl eines Tonsignals für den Alarm</string>
     <string name="alarm_vibration_signal_summary">Auswahl der Vibrationsdauer für den Alarm</string>
     <string name="location_provider_not_available">Location-Provider \'%s\' nicht verfügbar</string>
+    <string name="location_provider_disabled">Location-Provider \'%s\' ist deaktiviert</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -311,4 +311,5 @@
     <string name="alarm_audio_signal_summary">choose an audio notfication for alarm signalig</string>
     <string name="alarm_vibration_signal_summary">choose the duration of vibration signaling in alarm case</string>
     <string name="location_provider_not_available">location provider \'%s\' not available</string>
+    <string name="location_provider_disabled">location provider \'%s\' is disabled</string>
 </resources>


### PR DESCRIPTION
Indicate when the user selects a disabled location-provider.

Users might be tempted to think the app is broken,
because they have disabled gps but selected it in the app settings
and dont get any warnings.