### PR TITLE
Use "useLines" instead of "lineSequence"

### DIFF
--- a/app/src/main/java/org/blitzortung/android/data/provider/blitzortung/BlitzortungHttpDataProvider.kt
+++ b/app/src/main/java/org/blitzortung/android/data/provider/blitzortung/BlitzortungHttpDataProvider.kt
@@ -126,10 +126,12 @@ class BlitzortungHttpDataProvider @JvmOverloads constructor(private val urlForma
             throw RuntimeException("no credentials provided")
 
         return readerSeq.filterNotNull().flatMap {
-            val tmpList = it.lineSequence().mapNotNull {
-                size += it.length
+            val tmpList = it.useLines {
+                it.mapNotNull { line ->
+                    size += line.length
 
-                return@mapNotNull parse(it)
+                    return@mapNotNull parse(line)
+                }
             }
 
             Log.v(Main.LOG_TAG,


### PR DESCRIPTION
Current code just retrieves the sequence of lines, parses them and then goes on,
but the reader is never closed.

We should rather use BufferedReader.useLines { }, which does the same thing and additionally it closes the reader afterwards