### PR TITLE
Fixed bug with failing dialogs

### DIFF
--- a/app/src/main/java/org/blitzortung/android/app/Main.kt
+++ b/app/src/main/java/org/blitzortung/android/app/Main.kt
@@ -481,7 +481,7 @@ class Main : OwnMapActivity(), OnSharedPreferenceChangeListener {
         participantsOverlay.clear()
     }
 
-    override fun onCreateDialog(id: Int, args: Bundle): Dialog? {
+    override fun onCreateDialog(id: Int, args: Bundle?): Dialog? {
         return when (id) {
             R.id.info_dialog -> InfoDialog(this, versionComponent)
 


### PR DESCRIPTION
Creating dialogs (like Alert-Dialog, ...) fails since commit 14fcf1939d0dce7dcf4a68b4ff3afd7f9d91444d.

Fixed now