### PR TITLE
Location handler refactoring

### DIFF
--- a/app/src/main/java/org/blitzortung/android/app/Main.kt
+++ b/app/src/main/java/org/blitzortung/android/app/Main.kt
@@ -28,6 +28,7 @@ import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.graphics.Color
+import android.location.LocationManager
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
@@ -51,7 +52,6 @@ import org.blitzortung.android.app.view.components.StatusComponent
 import org.blitzortung.android.app.view.get
 import org.blitzortung.android.data.provider.result.*
 import org.blitzortung.android.dialogs.*
-import org.blitzortung.android.location.LocationHandler
 import org.blitzortung.android.map.OwnMapActivity
 import org.blitzortung.android.map.OwnMapView
 import org.blitzortung.android.map.overlay.FadeOverlay
@@ -525,16 +525,14 @@ class Main : OwnMapActivity(), OnSharedPreferenceChangeListener {
     @TargetApi(Build.VERSION_CODES.M)
     private fun requestPermissions(sharedPreferences: SharedPreferences) {
 
-        val newProvider = LocationHandler.Provider.fromString(sharedPreferences.get(PreferenceKey.LOCATION_MODE, LocationHandler.Provider.PASSIVE.type))
-        if (newProvider === LocationHandler.Provider.PASSIVE || newProvider === LocationHandler.Provider.GPS) {
-            if (checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                requestPermissions(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION), Main.REQUEST_GPS)
-            }
+        val permission = when(sharedPreferences.get(PreferenceKey.LOCATION_MODE, LocationManager.PASSIVE_PROVIDER)) {
+            LocationManager.PASSIVE_PROVIDER, LocationManager.GPS_PROVIDER -> Manifest.permission.ACCESS_FINE_LOCATION
+            LocationManager.NETWORK_PROVIDER -> Manifest.permission.ACCESS_COARSE_LOCATION
+            else -> null
         }
-        if (newProvider === LocationHandler.Provider.NETWORK) {
-            if (checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                requestPermissions(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION), Main.REQUEST_GPS)
-            }
+
+        if(permission is String && checkSelfPermission(permission) != PackageManager.PERMISSION_GRANTED) {
+            requestPermissions(arrayOf(permission), Main.REQUEST_GPS)
         }
     }
 

--- a/app/src/main/java/org/blitzortung/android/app/view/PreferenceKey.kt
+++ b/app/src/main/java/org/blitzortung/android/app/view/PreferenceKey.kt
@@ -21,7 +21,7 @@ package org.blitzortung.android.app.view
 import android.content.SharedPreferences
 import java.util.*
 
-enum class PreferenceKey internal constructor(private val key: String) {
+enum class PreferenceKey internal constructor(val key: String) {
     USERNAME("username"),
     PASSWORD("password"),
     SERVICE_URL("service_url"),
@@ -88,4 +88,29 @@ internal inline fun <reified T> SharedPreferences.get(prefKey: PreferenceKey, de
     }
 
     return value as T
+}
+
+internal inline fun <reified T, V> SharedPreferences.getAndConvert(prefKey: PreferenceKey, default: T, convert: (T) -> V): V {
+    val value = this.get(prefKey, default)
+    return convert(value)
+}
+
+/**
+ *  A generic extension function to set a SharedPreference-Value
+ */
+internal inline fun <reified T> SharedPreferences.Editor.put(key: String, value: T) {
+    when(value) {
+        is String -> this.putString(key, value)
+        is Int -> this.putInt(key, value)
+        is Boolean -> this.putBoolean(key, value)
+        is Float -> this.putFloat(key, value)
+        is Long -> this.putLong(key, value)
+        else -> throw IllegalArgumentException("Type ${T::class} cannoted be put inside a SharedPreference")
+    }
+}
+
+internal inline fun <reified T> SharedPreferences.Editor.put(key: PreferenceKey, value: T) {
+    val keyString = key.key
+
+    put(keyString, value)
 }

--- a/app/src/main/java/org/blitzortung/android/location/LocationHandler.kt
+++ b/app/src/main/java/org/blitzortung/android/location/LocationHandler.kt
@@ -274,4 +274,7 @@ class LocationHandler(
         }
     }
 
+    companion object {
+        val MANUAL_PROVIDER = "manual"
+    }
 }

--- a/app/src/main/java/org/blitzortung/android/location/provider/GPSLocationProvider.kt
+++ b/app/src/main/java/org/blitzortung/android/location/provider/GPSLocationProvider.kt
@@ -1,0 +1,53 @@
+package org.blitzortung.android.location.provider
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.GpsStatus
+import android.location.Location
+import android.location.LocationManager
+import android.support.v4.content.PermissionChecker
+
+class GPSLocationProvider(context: Context,
+                          backgroundMode: Boolean,
+                          locationUpdate: (Location?) -> Unit)
+: ManagerLocationProvider(context, backgroundMode, locationUpdate, LocationManager.GPS_PROVIDER), GpsStatus.Listener {
+    override fun start() {
+        super.start()
+
+        locationManager.addGpsStatusListener(this)
+    }
+
+    override fun shutdown() {
+        locationManager.removeGpsStatusListener(this)
+
+        super.shutdown()
+    }
+
+    override fun onGpsStatusChanged(event: Int) {
+        when (event) {
+            GpsStatus.GPS_EVENT_SATELLITE_STATUS -> {
+                val lastKnownGpsLocation = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER)
+                if (lastKnownGpsLocation != null) {
+                    val secondsElapsedSinceLastFix = (System.currentTimeMillis() - lastKnownGpsLocation.time) / 1000
+
+                    if (secondsElapsedSinceLastFix < 10) {
+                        if (!location.isValid) {
+                            location.set(lastKnownGpsLocation)
+                            sendLocationUpdate()
+                        }
+                    }
+                }
+                if (location.isValid) {
+                    invalidateLocationAndSendLocationUpdate()
+                }
+            }
+        }
+    }
+
+    override val minTime: Long
+        get() = if(backgroundMode) 1200 else 1000
+
+    override val isPermissionGranted: Boolean
+        get() = PermissionChecker.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+}

--- a/app/src/main/java/org/blitzortung/android/location/provider/LocationProvider.kt
+++ b/app/src/main/java/org/blitzortung/android/location/provider/LocationProvider.kt
@@ -1,0 +1,44 @@
+package org.blitzortung.android.location.provider
+
+import android.location.Location
+import android.util.Log
+import org.blitzortung.android.app.Main
+
+abstract class LocationProvider(protected val locationUpdate: (Location?) -> Unit) {
+    protected var location = Location("")
+
+    var isRunning: Boolean = false
+        private set
+
+    abstract val isEnabled: Boolean
+
+    protected fun sendLocationUpdate() {
+        locationUpdate(location)
+    }
+
+    abstract val type: String
+
+    protected val Location.isValid: Boolean
+        get() = !java.lang.Double.isNaN(longitude) && !java.lang.Double.isNaN(latitude)
+
+    protected fun invalidateLocationAndSendLocationUpdate() {
+        locationUpdate(null)
+
+        invalidateLocation()
+    }
+
+    protected  fun invalidateLocation() {
+        location = Location("")
+    }
+
+    open fun start() {
+        isRunning = true
+        Log.v(Main.LOG_TAG, "Provider $type started" )
+    }
+
+    open fun shutdown() {
+        isRunning = false
+        invalidateLocationAndSendLocationUpdate()
+        Log.v(Main.LOG_TAG, "Provider $type stopped" )
+    }
+}

--- a/app/src/main/java/org/blitzortung/android/location/provider/LocationProviderFactory.kt
+++ b/app/src/main/java/org/blitzortung/android/location/provider/LocationProviderFactory.kt
@@ -1,0 +1,20 @@
+package org.blitzortung.android.location.provider
+
+import android.content.Context
+import android.location.Location
+import android.location.LocationManager
+import org.blitzortung.android.location.LocationHandler
+import org.jetbrains.anko.defaultSharedPreferences
+
+
+internal fun createLocationProvider(context: Context, backgroundMode: Boolean, tmp: (Location?) -> Unit, providerName: String): LocationProvider {
+    val provider = when(providerName) {
+        LocationManager.GPS_PROVIDER -> GPSLocationProvider(context, backgroundMode, tmp)
+        LocationManager.NETWORK_PROVIDER -> NetworkLocationProvider(context, backgroundMode, tmp)
+        LocationManager.PASSIVE_PROVIDER -> PassiveLocationProvider(context, backgroundMode, tmp)
+        LocationHandler.MANUAL_PROVIDER -> ManualLocationProvider(tmp, context.defaultSharedPreferences)
+        else -> null
+    } ?: throw IllegalArgumentException("Cannot find provider for name $providerName")
+
+    return provider
+}

--- a/app/src/main/java/org/blitzortung/android/location/provider/ManagerLocationProvider.kt
+++ b/app/src/main/java/org/blitzortung/android/location/provider/ManagerLocationProvider.kt
@@ -1,0 +1,55 @@
+package org.blitzortung.android.location.provider
+
+import android.content.Context
+import android.location.Location
+import android.location.LocationListener
+import android.os.Bundle
+import org.jetbrains.anko.locationManager
+
+abstract class ManagerLocationProvider(protected val context: Context,
+                                   var backgroundMode: Boolean = true,
+                                   locationUpdate: (Location?) -> Unit,
+                                   override val type: String)
+: LocationProvider(locationUpdate), LocationListener {
+
+    protected val locationManager = context.locationManager
+
+    protected open val minTime: Long
+        get() = if(backgroundMode) 12000 else 20000
+
+    protected open val minDistance: Float
+        get() = if(backgroundMode) 200f else 50f
+
+    override fun start() {
+        super.start()
+
+        locationManager.requestLocationUpdates(type, minTime, minDistance, this)
+    }
+
+    override fun onLocationChanged(location: Location?) {
+        //We don't want to send NULL to the listeners
+        if(location is Location) {
+            this.location.set(location)
+
+            sendLocationUpdate()
+        }
+    }
+
+    override fun onProviderDisabled(provider: String) { }
+
+    override fun onProviderEnabled(provider: String) { }
+
+    override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) { }
+
+    override val isEnabled: Boolean
+        get() = locationManager.isProviderEnabled(type)
+
+
+    override fun shutdown() {
+        locationManager.removeUpdates(this)
+
+        super.shutdown()
+    }
+
+    abstract val isPermissionGranted: Boolean
+}

--- a/app/src/main/java/org/blitzortung/android/location/provider/ManualLocationProvider.kt
+++ b/app/src/main/java/org/blitzortung/android/location/provider/ManualLocationProvider.kt
@@ -1,0 +1,53 @@
+package org.blitzortung.android.location.provider
+
+import android.content.SharedPreferences
+import android.location.Location
+import android.util.Log
+import org.blitzortung.android.app.Main
+import org.blitzortung.android.app.view.PreferenceKey
+import org.blitzortung.android.app.view.getAndConvert
+import org.blitzortung.android.location.LocationHandler
+
+class ManualLocationProvider(locationUpdate: (Location?) -> Unit, private val sharedPreferences: SharedPreferences) : LocationProvider(locationUpdate), SharedPreferences.OnSharedPreferenceChangeListener {
+    override val isEnabled: Boolean = true
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+        onSharedPreferenceChanged(sharedPreferences, PreferenceKey.fromString(key))
+    }
+
+    private fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: PreferenceKey) {
+        val doubleConverter: (String) -> Double? = {x: String ->
+            try {
+                java.lang.Double.valueOf(x)
+            } catch (e: NumberFormatException) {
+                Log.e(Main.LOG_TAG, "bad longitude/latitude number format '$x'")
+            }
+
+            null
+        }
+
+        when(key) {
+            PreferenceKey.LOCATION_LONGITUDE -> {
+                location.longitude = sharedPreferences.getAndConvert(key, "49.0", doubleConverter) ?: 49.0
+                sendLocationUpdate()
+            }
+            PreferenceKey.LOCATION_LATITUDE -> {
+                location.latitude = sharedPreferences.getAndConvert(key, "11.0", doubleConverter) ?: 11.0
+                sendLocationUpdate()
+            }
+        }
+    }
+
+    override val type = LocationHandler.MANUAL_PROVIDER
+
+    override fun start() {
+        sharedPreferences.registerOnSharedPreferenceChangeListener(this)
+
+        onSharedPreferenceChanged(sharedPreferences, PreferenceKey.LOCATION_LONGITUDE)
+        onSharedPreferenceChanged(sharedPreferences, PreferenceKey.LOCATION_LATITUDE)
+    }
+
+    override fun shutdown() {
+        sharedPreferences.unregisterOnSharedPreferenceChangeListener(this)
+    }
+}

--- a/app/src/main/java/org/blitzortung/android/location/provider/NetworkLocationProvider.kt
+++ b/app/src/main/java/org/blitzortung/android/location/provider/NetworkLocationProvider.kt
@@ -1,0 +1,17 @@
+package org.blitzortung.android.location.provider
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.Location
+import android.location.LocationManager
+import android.support.v4.content.PermissionChecker
+
+class NetworkLocationProvider(context: Context,
+                              backgroundMode: Boolean,
+                              locationUpdate: (Location?) -> Unit)
+: ManagerLocationProvider(context, backgroundMode, locationUpdate, LocationManager.NETWORK_PROVIDER) {
+
+    override val isPermissionGranted: Boolean
+        get() = PermissionChecker.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
+}

--- a/app/src/main/java/org/blitzortung/android/location/provider/PassiveLocationProvider.kt
+++ b/app/src/main/java/org/blitzortung/android/location/provider/PassiveLocationProvider.kt
@@ -1,0 +1,17 @@
+package org.blitzortung.android.location.provider
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.Location
+import android.location.LocationManager
+import android.support.v4.content.PermissionChecker
+
+class PassiveLocationProvider(context: Context,
+                              backgroundMode: Boolean,
+                              locationUpdate: (Location?) -> Unit)
+: ManagerLocationProvider(context, backgroundMode, locationUpdate, LocationManager.PASSIVE_PROVIDER) {
+
+    override val isPermissionGranted: Boolean
+        get() = PermissionChecker.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+}

--- a/app/src/main/java/org/blitzortung/android/map/OwnMapView.kt
+++ b/app/src/main/java/org/blitzortung/android/map/OwnMapView.kt
@@ -78,7 +78,7 @@ class OwnMapView : MapView {
             val editor = preferences.edit()
             editor.putString(PreferenceKey.LOCATION_LONGITUDE.toString(), longitude.toString())
             editor.putString(PreferenceKey.LOCATION_LATITUDE.toString(), latitude.toString())
-            editor.putString(PreferenceKey.LOCATION_MODE.toString(), LocationHandler.Provider.MANUAL.type)
+            editor.putString(PreferenceKey.LOCATION_MODE.toString(), LocationHandler.MANUAL_PROVIDER)
             editor.apply()
             Toast.makeText(context, "%s: %.4f %.4f".format(locationText, longitude, latitude),
                     Toast.LENGTH_LONG).show()


### PR DESCRIPTION
So I've created a LocationProvider class for every Provider.
When the user chooses a disabled Provider inside the preferences,
the Location-Settings-Activity is started.

The provider variable is set inside LocationHandler, and
as soon as the underlying provider is enabled, our LocationProvider is started too.

If we don't have permission to retrieve the Location, the "manual" provider is used

Fixes #82 and #81 