### PR TITLE
Invalidate the own location, when the LocationProvider broadcasts null

### DIFF
--- a/app/src/main/java/org/blitzortung/android/map/overlay/OwnLocationOverlay.kt
+++ b/app/src/main/java/org/blitzortung/android/map/overlay/OwnLocationOverlay.kt
@@ -48,7 +48,7 @@ class OwnLocationOverlay(context: Context, mapView: OwnMapView) : ItemizedOverla
         val location = event.location
 
         if (enabled) {
-            item = if (location != null) OwnLocationOverlayItem(location) else item
+            item = location?.run { OwnLocationOverlayItem(location) }
 
             populate()
             refresh()


### PR DESCRIPTION
A problem arises from the current way the own Location is handled inside OwnLocationOverlay.

Lets say the user switches from Manual Provider to GPS (GPS is disabled):

When switching the Provider, a NULL Location is broadcasted.
The AlertHandler disables the warnings, because of a non-existing own Location.
On the other hand the own Location is still showed on the Map.
The user is tempted to think, that Warnings are working (Warnings are enabled + the own Location is shown on the Map), but Warnings aren't really enabled in the background.

So we should invalidate the own Location when a NULL Location is broadcasted.