### PR TITLE
Set Default preferences as early as possible

### DIFF
--- a/app/src/main/java/org/blitzortung/android/app/BOApplication.kt
+++ b/app/src/main/java/org/blitzortung/android/app/BOApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.SharedPreferences
 import android.content.pm.PackageInfo
 import android.os.PowerManager
+import android.preference.PreferenceManager
 import org.blitzortung.android.alert.handler.AlertHandler
 import org.blitzortung.android.data.DataHandler
 import org.blitzortung.android.location.LocationHandler
@@ -15,6 +16,9 @@ class BOApplication : Application() {
         super.onCreate()
 
         backgroundModeHandler = BackgroundModeHandler(this)
+
+        //First of all, set the default values
+        PreferenceManager.setDefaultValues(this, R.xml.preferences, false)
 
         sharedPreferences = applicationContext.defaultSharedPreferences
 

--- a/app/src/main/java/org/blitzortung/android/app/Main.kt
+++ b/app/src/main/java/org/blitzortung/android/app/Main.kt
@@ -180,7 +180,6 @@ class Main : OwnMapActivity(), OnSharedPreferenceChangeListener {
         mapView.setBuiltInZoomControls(true)
         this.mapView = mapView
 
-        PreferenceManager.setDefaultValues(this, R.xml.preferences, false)
         preferences.registerOnSharedPreferenceChangeListener(this)
 
         strikesOverlay = StrikesOverlay(this, StrikeColorHandler(preferences))


### PR DESCRIPTION
Setting default preferences inside Main causes a bug on new installations.
where AlertHandler thinks that alerts are disabled, but after setting the default preferences, alerts are enabled

