### PR TITLE
Use a PopupMenu instead of the built-in OptionsMenu.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
 
         <activity
             android:name=".Main"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:theme="@style/Base.V7.Theme.AppCompat">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/org/blitzortung/android/app/Main.kt
+++ b/app/src/main/java/org/blitzortung/android/app/Main.kt
@@ -64,7 +64,6 @@ import org.blitzortung.android.map.overlay.color.StrikeColorHandler
 import org.blitzortung.android.util.TabletAwareView
 import org.blitzortung.android.util.isAtLeast
 import org.jetbrains.anko.intentFor
-import org.jetbrains.anko.startActivity
 
 class Main : OwnMapActivity(), OnSharedPreferenceChangeListener {
     private val androidIdsForExtendedFunctionality = setOf("44095eb4f9f1a6a6", "f2be4516e5843964")
@@ -381,27 +380,6 @@ class Main : OwnMapActivity(), OnSharedPreferenceChangeListener {
             return dbg
         }
 
-    override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        super.onCreateOptionsMenu(menu)
-        val inflater = menuInflater
-        inflater.inflate(R.menu.main_menu, menu)
-
-        return true
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        when (item.itemId) {
-            R.id.menu_info -> showDialog(R.id.info_dialog)
-
-            R.id.menu_alarms -> showDialog(R.id.alarm_dialog)
-
-            R.id.menu_log -> showDialog(R.id.log_dialog)
-
-            R.id.menu_preferences -> startActivity<Preferences>()
-        }
-        return super.onOptionsItemSelected(item)
-    }
-
     override fun onStart() {
         super.onStart()
 
@@ -501,21 +479,6 @@ class Main : OwnMapActivity(), OnSharedPreferenceChangeListener {
 
         strikesOverlay.clear()
         participantsOverlay.clear()
-    }
-
-    override fun onCreateDialog(id: Int, args: Bundle?): Dialog? {
-        return when (id) {
-            R.id.info_dialog -> InfoDialog(this, versionComponent)
-
-            R.id.alarm_dialog ->
-                appService?.let { appService ->
-                    AlertDialog(this, appService, AlertDialogColorHandler(PreferenceManager.getDefaultSharedPreferences(this)))
-                }
-
-            R.id.log_dialog -> LogDialog(this)
-
-            else -> throw RuntimeException("unhandled dialog with id $id")
-        }
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
@@ -633,7 +596,11 @@ class Main : OwnMapActivity(), OnSharedPreferenceChangeListener {
                 isAtLeast(Build.VERSION_CODES.ICE_CREAM_SANDWICH) &&
                         !config.hasPermanentMenuKey()) {
             menu.visibility = View.VISIBLE
-            menu.setOnClickListener { v -> openOptionsMenu() }
+            menu.setOnClickListener {
+                val popupMenu = MainPopupMenu(this, menu)
+                popupMenu.showPopupMenu()
+            }
+
             buttonColumnHandler.addElement(menu)
         }
     }

--- a/app/src/main/java/org/blitzortung/android/app/MainPopupMenu.kt
+++ b/app/src/main/java/org/blitzortung/android/app/MainPopupMenu.kt
@@ -1,0 +1,44 @@
+package org.blitzortung.android.app
+
+import android.app.Dialog
+import android.content.Context
+import android.support.v7.view.menu.MenuBuilder
+import android.support.v7.widget.PopupMenu
+import android.view.MenuItem
+import android.view.View
+import org.blitzortung.android.app.components.VersionComponent
+import org.blitzortung.android.dialogs.AlertDialog
+import org.blitzortung.android.dialogs.AlertDialogColorHandler
+import org.blitzortung.android.dialogs.InfoDialog
+import org.blitzortung.android.dialogs.LogDialog
+import org.jetbrains.anko.startActivity
+
+class MainPopupMenu(private val context: Context, anchor: View) : PopupMenu(context, anchor) {
+    override fun onMenuItemSelected(menu: MenuBuilder?, item: MenuItem): Boolean {
+        val versionComponent = VersionComponent(context)
+        if(item.itemId == R.id.menu_preferences) {
+            context.startActivity<Preferences>()
+        } else {
+            val dialog = when (item.itemId) {
+                R.id.menu_info -> InfoDialog(context, versionComponent)
+
+                R.id.menu_alarms -> AlertDialog(context, AppService.instance, AlertDialogColorHandler(BOApplication.sharedPreferences))
+
+                R.id.menu_log -> LogDialog(context)
+
+                else -> null
+            }
+
+            if(dialog is Dialog) {
+                dialog.show()
+            }
+        }
+
+        return super.onMenuItemSelected(menu, item)
+    }
+
+    fun showPopupMenu() {
+        inflate(R.menu.main_menu)
+        show()
+    }
+}


### PR DESCRIPTION
Created MainPopupMenu, which is responsible for handling all stuff related to the Main-Menu.
 Had to declare a theme for the activity to prevent RuntimeExceptions when displaying the PopupMenu.

Fixes #109
Fixes #35 