### PR TITLE
Fix rotation bug in 1.5.0

### DIFF
--- a/app/src/main/java/org/blitzortung/android/app/Main.kt
+++ b/app/src/main/java/org/blitzortung/android/app/Main.kt
@@ -383,9 +383,7 @@ class Main : OwnMapActivity(), OnSharedPreferenceChangeListener {
     override fun onStart() {
         super.onStart()
 
-        if (appService != null) {
-            setupDataUpdates()
-        }
+        setupDataUpdates()
 
         Log.d(Main.LOG_TAG, "Main.onStart() service: " + appService)
     }


### PR DESCRIPTION
The dataConsumerContainer always stored and broadcasted the events,
so the currentPayload after rotating the screen was a StatusEvent instead of the latest ResultEvent