### PR TITLE
Only draw Raster Items, when they are visible

### DIFF
--- a/app/src/main/java/org/blitzortung/android/map/overlay/RasterShape.kt
+++ b/app/src/main/java/org/blitzortung/android/map/overlay/RasterShape.kt
@@ -38,6 +38,11 @@ class RasterShape : Shape() {
     }
 
     override fun draw(canvas: Canvas, paint: Paint) {
+        //Only draw visible Raster-Items
+        if(canvas.quickReject(rect, Canvas.EdgeType.BW)){
+            return
+        }
+
         paint.color = color
         paint.alpha = alpha
         canvas.drawRect(rect, paint)


### PR DESCRIPTION
Right now every Raster-Item is always drawn onto the canvas.
That consumes a lot of CPU-Power and degrade performance when many storms are undergoing.

With this small change, only currently visible Raster-Items will be drawn on the canvas