### PR TITLE
Own location size

### DIFF
--- a/app/src/main/java/org/blitzortung/android/app/Preferences.kt
+++ b/app/src/main/java/org/blitzortung/android/app/Preferences.kt
@@ -44,6 +44,7 @@ class Preferences : PreferenceActivity(), OnSharedPreferenceChangeListener {
 
         configureDataSourcePreferences(prefs)
         configureLocationProviderPreferences(prefs)
+        configureOwnLocationSizePreference(prefs)
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, keyString: String) {
@@ -66,12 +67,20 @@ class Preferences : PreferenceActivity(), OnSharedPreferenceChangeListener {
                 val provider = configureLocationProviderPreferences(sharedPreferences)
 
                 if(provider != LocationHandler.MANUAL_PROVIDER && !this.locationManager.isProviderEnabled(provider)) {
-                    startActivity(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS));
+                    startActivity(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS))
                 }
+            }
+
+            PreferenceKey.SHOW_LOCATION -> {
+                configureOwnLocationSizePreference(sharedPreferences)
             }
 
             else -> {}
         }
+    }
+
+    private fun configureOwnLocationSizePreference(sharedPreferences: SharedPreferences) {
+        findPreference("own_location_size").isEnabled = sharedPreferences.get(PreferenceKey.SHOW_LOCATION, false)
     }
 
     private fun configureDataSourcePreferences(sharedPreferences: SharedPreferences): DataProviderType {

--- a/app/src/main/java/org/blitzortung/android/app/view/PreferenceKey.kt
+++ b/app/src/main/java/org/blitzortung/android/app/view/PreferenceKey.kt
@@ -21,7 +21,7 @@ package org.blitzortung.android.app.view
 import android.content.SharedPreferences
 import java.util.*
 
-enum class PreferenceKey private constructor(val key: String) {
+enum class PreferenceKey(val key: String) {
     USERNAME("username"),
     PASSWORD("password"),
     SERVICE_URL("service_url"),
@@ -34,6 +34,7 @@ enum class PreferenceKey private constructor(val key: String) {
     BACKGROUND_QUERY_PERIOD("background_query_period"),
     SHOW_PARTICIPANTS("show_participants"),
     SHOW_LOCATION("location"),
+    OWN_LOCATION_SIZE("own_location_size"),
     ALERT_ENABLED("alarm_enabled"),
     ALERT_SOUND_SIGNAL("alarm_sound_signal"),
     ALERT_VIBRATION_SIGNAL("alarm_vibration_signal"),
@@ -125,6 +126,6 @@ interface OnSharedPreferenceChangeListener : SharedPreferences.OnSharedPreferenc
         onSharedPreferenceChanged(sharedPreferences, PreferenceKey.fromString(keyString))
     }
 
-    fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: PreferenceKey);
+    fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: PreferenceKey)
 
 }

--- a/app/src/main/java/org/blitzortung/android/map/overlay/OwnLocationOverlay.kt
+++ b/app/src/main/java/org/blitzortung/android/map/overlay/OwnLocationOverlay.kt
@@ -23,23 +23,28 @@ import android.content.SharedPreferences
 import android.graphics.Canvas
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.ShapeDrawable
-import android.preference.PreferenceManager
 import com.google.android.maps.ItemizedOverlay
 import org.blitzortung.android.app.BOApplication
 import org.blitzortung.android.app.R
 import org.blitzortung.android.app.helper.ViewHelper
 import org.blitzortung.android.app.view.PreferenceKey
 import org.blitzortung.android.app.view.get
+import org.blitzortung.android.app.view.getAndConvert
 import org.blitzortung.android.location.LocationEvent
 import org.blitzortung.android.map.OwnMapView
 import org.blitzortung.android.map.components.LayerOverlayComponent
 import org.blitzortung.android.util.TabletAwareView
 
-class OwnLocationOverlay(context: Context, private val mapView: OwnMapView) : ItemizedOverlay<OwnLocationOverlayItem>(OwnLocationOverlay.DEFAULT_DRAWABLE), SharedPreferences.OnSharedPreferenceChangeListener, LayerOverlay {
+class OwnLocationOverlay(context: Context, private val mapView: OwnMapView) :
+        ItemizedOverlay<OwnLocationOverlayItem>(OwnLocationOverlay.DEFAULT_DRAWABLE),
+        SharedPreferences.OnSharedPreferenceChangeListener,
+        LayerOverlay {
 
     private val layerOverlayComponent: LayerOverlayComponent
 
     private var item: OwnLocationOverlayItem? = null
+
+    private var symbolSize: Float = 1.0f
 
     private val sizeFactor: Float
 
@@ -78,7 +83,8 @@ class OwnLocationOverlay(context: Context, private val mapView: OwnMapView) : It
 
         val preferences = BOApplication.sharedPreferences
         preferences.registerOnSharedPreferenceChangeListener(this)
-        onSharedPreferenceChanged(preferences, PreferenceKey.SHOW_LOCATION.toString())
+        onSharedPreferenceChanged(preferences, PreferenceKey.SHOW_LOCATION)
+        onSharedPreferenceChanged(preferences, PreferenceKey.OWN_LOCATION_SIZE)
 
         refresh()
     }
@@ -90,7 +96,7 @@ class OwnLocationOverlay(context: Context, private val mapView: OwnMapView) : It
     }
 
     private fun refresh() {
-        item?.run { setMarker(ShapeDrawable(OwnLocationShape(sizeFactor * zoomLevel))) }
+        item?.run { setMarker(ShapeDrawable(OwnLocationShape(sizeFactor * zoomLevel * symbolSize))) }
 
         //Redraw when the OwnLocation is refreshed
         mapView.postInvalidate()
@@ -128,6 +134,10 @@ class OwnLocationOverlay(context: Context, private val mapView: OwnMapView) : It
                 enableOwnLocation()
             } else {
                 disableOwnLocation()
+            }
+        } else if(key == PreferenceKey.OWN_LOCATION_SIZE) {
+            symbolSize = sharedPreferences.getAndConvert(PreferenceKey.OWN_LOCATION_SIZE, 100) {
+                it.toFloat() / 100
             }
         }
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -72,7 +72,7 @@
         Datenquelle)
     </string>
     <string name="show_location">Standort anzeigen</string>
-    <string name="show_location_summary">eigenen Standort als Symbol in der Karte anzeigen</string>
+    <string name="show_location_summary">Eigenen Standort als Symbol in der Karte anzeigen</string>
     <string name="data_settings">Datenübertragung</string>
     <string name="region">Region auswählen</string>
     <string name="region_summary">Europa, Nordamerika oder Ozeanien</string>
@@ -343,4 +343,8 @@
     <string name="timeout_warning">Netzwerk-Zeitüberschreitung.\nBitte überprüfen sie die Internetverbindung.</string>
     <string name="connection_warning">Kein Netzwerk.\nBitte überprüfen sie die Internetverbindung.</string>
     <string name="provider_warning">Bitte nutzen sie die Blitzortung.org Datenquelle nicht bei hoher Blitzaktivität. Die Dastellung der Karte wird möglicherweise verzögert.</string>
+    <string name="own_location_summary" >Einstellungen der Anzeige des Standorts</string>
+    <string name="own_location" >Eigener Standort</string>
+    <string name="own_location_size" >Größe des Standort-Symbols</string>
+    <string name="own_location_size_summary" >Einstellung der Größe des Standort-Symbols</string>
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -3,4 +3,7 @@
     <declare-styleable name="View">
         <attr name="tablet_scaleable" format="boolean"/>
     </declare-styleable>
+    <declare-styleable name="org.blitzortung.android.preferences.SlidePreferences">
+        <attr name="min" format="integer" />
+    </declare-styleable>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,4 +348,8 @@
     <string name="timeout_warning">Network timeout.\nPlease check your network connectivity.</string>
     <string name="connection_warning">Could not connect.\nPlease check your network connectivity.</string>
     <string name="provider_warning">Please do not use the Blitzortung.org data provider during high lightning activity, as the map display performance will degrade.</string>
+    <string name="own_location_summary" >Own location Display-Settings</string>
+    <string name="own_location" >Own location</string>
+    <string name="own_location_size" >Own location symbol size</string>
+    <string name="own_location_size_summary" >Set the size of the own location symbol</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -101,6 +101,7 @@
                 android:selectable="true"
                 android:persistent="true"
                 android:text="%"
+                min="50"
                 />
         </PreferenceScreen>
     </PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -80,13 +80,29 @@
             android:selectable="true"
             android:summary="@string/show_participants_summary"
             android:title="@string/show_participants" />
-        <CheckBoxPreference
-            android:defaultValue="true"
-            android:enabled="true"
-            android:key="location"
-            android:selectable="true"
-            android:summary="@string/show_location_summary"
-            android:title="@string/show_location" />
+        <PreferenceScreen
+            android:key="own_location_settings"
+            android:summary="@string/own_location_summary"
+            android:title="@string/own_location">
+
+            <CheckBoxPreference
+                android:defaultValue="true"
+                android:enabled="true"
+                android:key="location"
+                android:selectable="true"
+                android:summary="@string/show_location_summary"
+                android:title="@string/show_location" />
+            <org.blitzortung.android.preferences.SlidePreferences
+                android:title="@string/own_location_size"
+                android:summary="@string/own_location_size_summary"
+                android:defaultValue="100"
+                android:key="own_location_size"
+                android:max="400"
+                android:selectable="true"
+                android:persistent="true"
+                android:text="%"
+                />
+        </PreferenceScreen>
     </PreferenceScreen>
     <PreferenceScreen
         android:key="data_settings"


### PR DESCRIPTION
This PR lets the user choose the size of the own location symbol.
By default its at 100% of the original size.

Range is from 50% to 400%.

A new PreferenceScreen for the 2 Settings of OwnLocation-Symbol has been created,
so right now there are some missing Translations.

And I'm not sure for what "own_location_layer" translation is used for. Maybe we can merge it together with the new "own_location" translation