### PR TITLE
Request lastKnownLocation only when starting a ManagerLocationProvider

### DIFF
--- a/app/src/main/java/org/blitzortung/android/location/provider/GPSLocationProvider.kt
+++ b/app/src/main/java/org/blitzortung/android/location/provider/GPSLocationProvider.kt
@@ -3,7 +3,6 @@ package org.blitzortung.android.location.provider
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
-import android.location.GpsStatus
 import android.location.Location
 import android.location.LocationManager
 import android.support.v4.content.PermissionChecker
@@ -11,37 +10,7 @@ import android.support.v4.content.PermissionChecker
 class GPSLocationProvider(context: Context,
                           backgroundMode: Boolean,
                           locationUpdate: (Location?) -> Unit)
-: ManagerLocationProvider(context, backgroundMode, locationUpdate, LocationManager.GPS_PROVIDER), GpsStatus.Listener {
-    override fun start() {
-        super.start()
-
-        if (isPermissionGranted) {
-            locationManager.addGpsStatusListener(this)
-        }
-    }
-
-    override fun shutdown() {
-        locationManager.removeGpsStatusListener(this)
-
-        super.shutdown()
-    }
-
-    override fun onGpsStatusChanged(event: Int) {
-        when (event) {
-            GpsStatus.GPS_EVENT_SATELLITE_STATUS -> {
-                val lastKnownGpsLocation = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER)
-                if (lastKnownGpsLocation != null) {
-                    val secondsElapsedSinceLastFix = (System.currentTimeMillis() - lastKnownGpsLocation.time) / 1000
-
-                    if (secondsElapsedSinceLastFix < 10) {
-                        if(lastKnownGpsLocation.isValid) {
-                            sendLocationUpdate(lastKnownGpsLocation)
-                        }
-                    }
-                }
-            }
-        }
-    }
+: ManagerLocationProvider(context, backgroundMode, locationUpdate, LocationManager.GPS_PROVIDER) {
 
     override val minTime: Long
         get() = if(backgroundMode) 1200 else 1000

--- a/app/src/main/java/org/blitzortung/android/location/provider/ManagerLocationProvider.kt
+++ b/app/src/main/java/org/blitzortung/android/location/provider/ManagerLocationProvider.kt
@@ -34,8 +34,18 @@ abstract class ManagerLocationProvider(
         super.start()
 
         Log.v(Main.LOG_TAG, "ManagerLocationProvider.start() background: $backgroundMode, type: $type, minTime: $minTime, minDistance: $minDistance")
-        if (locationManager.getAllProviders().contains(type)) {
+        if (locationManager.allProviders.contains(type)) {
             locationManager.requestLocationUpdates(type, minTime, minDistance, this)
+
+            //Now try to get the last known location from the current provider
+            val lastKnownLocation = locationManager.getLastKnownLocation(type)
+            if (lastKnownLocation != null) {
+                val secondsElapsedSinceLastFix = (System.currentTimeMillis() - lastKnownLocation.time) / 1000
+
+                if (secondsElapsedSinceLastFix < 30 && lastKnownLocation.isValid) {
+                    sendLocationUpdate(lastKnownLocation)
+                }
+            }
         } else {
             val message = "location provider ${type} is not available"
             Toast.makeText(context, "Warning:\n$message", Toast.LENGTH_LONG).show()


### PR DESCRIPTION
Right now the GPSLocationProvider listens for GPS_EVENT_SATELLITE_STATUS
and everytime such an event is received, the last known Location is broadcasted.

The Documentation https://developer.android.com/reference/android/location/GpsStatus.html#GPS_EVENT_SATELLITE_STATUS
says that this event is sent periodically(like every second or two),
that means we send out a new Location periodically and therefor recalculate the AlertView/OwnLocationShape every second.

This PR moves the code to retrieve the last known location into ManagerProvider.start()
so it will only be called when we start a ManagerProvider up