### PR TITLE
Created Preference to keep the current zoom level when centering own location

### DIFF
--- a/app/src/main/java/org/blitzortung/android/app/view/PreferenceKey.kt
+++ b/app/src/main/java/org/blitzortung/android/app/view/PreferenceKey.kt
@@ -49,7 +49,8 @@ enum class PreferenceKey(val key: String) {
     HISTORIC_TIMESTEP("historic_timestep"),
     LOCATION_MODE("location_mode"),
     LOCATION_LONGITUDE("location_longitude"),
-    LOCATION_LATITUDE("location_latitude");
+    LOCATION_LATITUDE("location_latitude"),
+    KEEP_ZOOM_GOTO_OWN_LOCATION("keep_zoom_goto_own_location");
 
     override fun toString(): String {
         return key

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -347,4 +347,6 @@
     <string name="own_location" >Eigener Standort</string>
     <string name="own_location_size" >Größe des Standort-Symbols</string>
     <string name="own_location_size_summary" >Einstellung der Größe des Standort-Symbols</string>
+    <string name="keep_zoom_goto_own_location_title" >Zoom beibehalten</string>
+    <string name="keep_zoom_goto_own_location_summary">Einstellung zur Beibehaltung des aktuellen Zooms beim Zentrieren des eigenen Standorts</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -352,4 +352,6 @@
     <string name="own_location" >Own location</string>
     <string name="own_location_size" >Own location symbol size</string>
     <string name="own_location_size_summary" >Set the size of the own location symbol</string>
+    <string name="keep_zoom_goto_own_location_summary" >Setting to keep the current zoom when centering the own location</string>
+    <string name="keep_zoom_goto_own_location_title" >Keep zoom</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -104,6 +104,13 @@
                 min="50"
                 />
         </PreferenceScreen>
+        <CheckBoxPreference
+            android:title="@string/keep_zoom_goto_own_location_title"
+            android:summary="@string/keep_zoom_goto_own_location_summary"
+            android:key="keep_zoom_goto_own_location"
+            android:selectable="true"
+            android:defaultValue="false"
+            android:persistent="true"/>
     </PreferenceScreen>
     <PreferenceScreen
         android:key="data_settings"


### PR DESCRIPTION
The new Preference allows the user to choose whether to keep the current
zoom level during centering the map on the own location.

Not sure about the text we should use as title/summary,
so feel free to change them.

Fixes #149 