### PR TITLE
Readded StrikePopup on Tap

### DIFF
--- a/app/src/main/java/org/blitzortung/android/map/StrikePopup.kt
+++ b/app/src/main/java/org/blitzortung/android/map/StrikePopup.kt
@@ -1,0 +1,28 @@
+package org.blitzortung.android.map
+
+import android.text.format.DateFormat
+import android.view.View
+import android.widget.TextView
+import org.blitzortung.android.app.R
+import org.blitzortung.android.map.overlay.RasterShape
+import org.blitzortung.android.map.overlay.StrikeOverlay
+import org.blitzortung.android.map.overlay.StrikeShape
+
+
+fun createStrikePopUp(popUp: View, strikeOverlay: StrikeOverlay): View {
+    var result = DateFormat.format("kk:mm:ss", strikeOverlay.timestamp) as String
+
+    if (strikeOverlay.shape is RasterShape) {
+        result += ", #%d".format(strikeOverlay.multiplicity)
+    } else if (strikeOverlay.shape is StrikeShape) {
+        result += " (%.4f %.4f)".format(strikeOverlay.center.longitudeE6 / 1e6, strikeOverlay.center.latitudeE6 / 1e6)
+    }
+
+    with(popUp.findViewById(R.id.popup_text) as TextView) {
+        setBackgroundColor(-2013265920)
+        setPadding(5, 5, 5, 5)
+        setText(result)
+    }
+
+    return popUp
+}

--- a/app/src/main/java/org/blitzortung/android/map/overlay/LightningShape.kt
+++ b/app/src/main/java/org/blitzortung/android/map/overlay/LightningShape.kt
@@ -2,8 +2,12 @@ package org.blitzortung.android.map.overlay
 
 import android.graphics.Canvas
 import android.graphics.Paint
+import com.google.android.maps.GeoPoint
 import com.google.android.maps.MapView
+import com.google.android.maps.Projection
 
 interface LightningShape {
     fun draw(canvas: Canvas, mapView: MapView, paint: Paint)
+
+    fun isPointInside(tappedGeoPoint: GeoPoint, projection: Projection): Boolean
 }

--- a/app/src/main/java/org/blitzortung/android/map/overlay/RasterShape.kt
+++ b/app/src/main/java/org/blitzortung/android/map/overlay/RasterShape.kt
@@ -25,6 +25,7 @@ import android.graphics.Point
 import android.graphics.RectF
 import com.google.android.maps.GeoPoint
 import com.google.android.maps.MapView
+import com.google.android.maps.Projection
 
 class RasterShape(private val center: GeoPoint) : LightningShape {
 
@@ -69,6 +70,17 @@ class RasterShape(private val center: GeoPoint) : LightningShape {
                     centerPoint.y.toFloat() + textSize / 2,
                     paint)
         }
+    }
+
+    override fun isPointInside(tappedGeoPoint: GeoPoint, projection: Projection): Boolean {
+        val shapeCenter = Point()
+        projection.toPixels(center, shapeCenter)
+
+        val tappedPoint = Point()
+        projection.toPixels(tappedGeoPoint, tappedPoint)
+
+        return tappedPoint.x >= shapeCenter.x + size.left && tappedPoint.x <= shapeCenter.x + size.right
+                && tappedPoint.y >= shapeCenter.y + size.top && tappedPoint.y <= shapeCenter.y + size.bottom
     }
 
     fun update(topLeft: Point, bottomRight: Point, color: Int, multiplicity: Int, textColor: Int) {

--- a/app/src/main/java/org/blitzortung/android/map/overlay/StrikeOverlay.kt
+++ b/app/src/main/java/org/blitzortung/android/map/overlay/StrikeOverlay.kt
@@ -3,9 +3,14 @@ package org.blitzortung.android.map.overlay
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Point
+import android.text.format.DateFormat
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
 import com.google.android.maps.GeoPoint
 import com.google.android.maps.MapView
 import com.google.android.maps.Projection
+import org.blitzortung.android.app.R
 import org.blitzortung.android.data.Coordsys
 import org.blitzortung.android.data.beans.RasterParameters
 import org.blitzortung.android.data.beans.Strike
@@ -13,7 +18,7 @@ import org.blitzortung.android.data.beans.Strike
 class StrikeOverlay(strike: Strike) {
     val timestamp: Long = strike.timestamp
     val multiplicity = strike.multiplicity
-    private val center: GeoPoint = Coordsys.toMapCoords(strike.longitude, strike.latitude)
+    val center: GeoPoint = Coordsys.toMapCoords(strike.longitude, strike.latitude)
 
     var shape: LightningShape? = null
 
@@ -54,6 +59,11 @@ class StrikeOverlay(strike: Strike) {
             }
         }
         this.shape = shape
+    }
+
+    fun pointIsInside(point: GeoPoint, projection: Projection): Boolean {
+        return shape?.isPointInside(point, projection)
+                ?: false
     }
 
     companion object {

--- a/app/src/main/java/org/blitzortung/android/map/overlay/StrikeShape.kt
+++ b/app/src/main/java/org/blitzortung/android/map/overlay/StrikeShape.kt
@@ -23,8 +23,19 @@ import android.graphics.Paint
 import android.graphics.Point
 import com.google.android.maps.GeoPoint
 import com.google.android.maps.MapView
+import com.google.android.maps.Projection
 
 class StrikeShape(private val center: GeoPoint) : LightningShape {
+    override fun isPointInside(tappedGeoPoint: GeoPoint, projection: Projection): Boolean {
+        val shapeCenter = Point()
+        projection.toPixels(center, shapeCenter)
+
+        val tappedPoint = Point()
+        projection.toPixels(tappedGeoPoint, tappedPoint)
+
+        return tappedPoint.x >= shapeCenter.x - size / 2 && tappedPoint.x <= shapeCenter.x + size / 2
+                && tappedPoint.y >= shapeCenter.y - size / 2 && tappedPoint.y <= shapeCenter.y + size / 2
+    }
 
     private var size: Float = 0.toFloat()
     private var color: Int = 0


### PR DESCRIPTION
Tap on a RasterShape works fine now.

Tap on a StrikeShape does work too, but right now its very hard to not miss it,
because the size of tap must be inside the size of the actual strike.

Dunno how we should fix this.
If we enlarge the "tap-rectangle" of a StrikeShape, its possible that you are not able
to tap onto a Strike that is too close to another one