### PR TITLE
Make strike alert aware of raster properties

### DIFF
--- a/app/src/main/java/org/blitzortung/android/alert/AlertLabelHandler.kt
+++ b/app/src/main/java/org/blitzortung/android/alert/AlertLabelHandler.kt
@@ -32,15 +32,16 @@ class AlertLabelHandler(
         var textColorResource = R.color.Green
 
         if (result != null && result.closestStrikeDistance < Float.POSITIVE_INFINITY) {
-            textColorResource = when(result.closestStrikeDistance) {
+            textColorResource = when (result.closestStrikeDistance) {
                 in 0.0..20.0 -> R.color.Red
                 in 20.0..50.0 -> R.color.Yellow
                 else -> R.color.Green
             }
-            warningText = "%.0f%s %s".format(
-                    result.closestStrikeDistance,
-                    resources.getString(result.parameters.measurementSystem.unitNameString),
-                    result.bearingName)
+            val distanceUnit = resources.getString(result.parameters.measurementSystem.unitNameString)
+            warningText = "%.0f$distanceUnit".format(result.closestStrikeDistance)
+            if (result.closestStrikeDistance > 0.1) {
+                warningText += " ${result.bearingName}"
+            }
         }
 
         val color = resources.getColor(textColorResource)

--- a/app/src/main/java/org/blitzortung/android/app/Main.kt
+++ b/app/src/main/java/org/blitzortung/android/app/Main.kt
@@ -58,6 +58,7 @@ import org.blitzortung.android.app.view.PreferenceKey
 import org.blitzortung.android.app.view.components.StatusComponent
 import org.blitzortung.android.app.view.get
 import org.blitzortung.android.app.view.put
+import org.blitzortung.android.data.DataChannel
 import org.blitzortung.android.data.MainDataHandler
 import org.blitzortung.android.data.provider.LOCAL_REGION
 import org.blitzortung.android.data.provider.result.DataEvent
@@ -247,6 +248,20 @@ class Main : FragmentActivity(), OnSharedPreferenceChangeListener {
             if (!StorageUtils.isWritable(osmDroidConfig.osmdroidTileCache)) {
                 Toast.makeText(baseContext, R.string.osmdroid_storage_warning, Toast.LENGTH_LONG).show()
             }
+        }
+    }
+
+    private fun setupDetailModeButton() {
+        with(toggleExtendedMode) {
+            isEnabled = true
+            visibility = View.VISIBLE
+
+            setOnClickListener {
+                dataHandler.toggleExtendedMode()
+                dataHandler.updateData(setOf(DataChannel.STRIKES))
+            }
+
+            buttonColumnHandler.addElement(this, ButtonGroup.DATA_UPDATING)
         }
     }
 

--- a/app/src/main/java/org/blitzortung/android/app/Main.kt
+++ b/app/src/main/java/org/blitzortung/android/app/Main.kt
@@ -148,16 +148,20 @@ class Main : FragmentActivity(), OnSharedPreferenceChangeListener {
                         referenceTime = event.referenceTime
                     }
 
-                    if (event.incrementalData && !initializeOverlay) {
+                    if (event.updated >= 0 && !initializeOverlay) {
                         strikeListOverlay.expireStrikes()
                     } else {
                         strikeListOverlay.clear()
                     }
 
-                    if (initializeOverlay && event.totalStrikes != null) {
-                        strikeListOverlay.addStrikes(event.totalStrikes)
-                    } else if (event.strikes != null) {
-                        strikeListOverlay.addStrikes(event.strikes)
+                    if (event.strikes != null) {
+                        val strikes = if (event.updated > 0 && !initializeOverlay) {
+                            val size = event.strikes.size
+                            event.strikes.subList(size - event.updated, size)
+                        } else {
+                            event.strikes
+                        }
+                        strikeListOverlay.addStrikes(strikes)
                     }
 
                     alert_view.setColorHandler(strikeColorHandler, strikeListOverlay.parameters.intervalDuration)

--- a/app/src/main/java/org/blitzortung/android/app/view/HistogramView.kt
+++ b/app/src/main/java/org/blitzortung/android/app/view/HistogramView.kt
@@ -129,42 +129,41 @@ class HistogramView @JvmOverloads constructor(
         } else {
             val histogram = dataEvent.histogram
 
-            var viewShouldBeVisible = histogram != null && histogram.isNotEmpty()
+            var hasHistogram = histogram != null && histogram.isNotEmpty()
 
-            this.histogram = histogram
-
-            if (!viewShouldBeVisible) {
-                viewShouldBeVisible = createHistogram(dataEvent)
+            this.histogram = if (hasHistogram) {
+                histogram
+            } else {
+                createHistogram(dataEvent)
             }
 
-            visibility = if (viewShouldBeVisible) VISIBLE else INVISIBLE
+            visibility = if (hasHistogram) VISIBLE else INVISIBLE
 
-            if (viewShouldBeVisible) {
+            if (hasHistogram) {
                 invalidate()
             }
         }
     }
 
-    private fun createHistogram(result: ResultEvent): Boolean {
+    private fun createHistogram(result: ResultEvent): IntArray {
         result.parameters.let { parameters ->
-            if (result.totalStrikes == null) {
-                return false
+            if (result.strikes == null) {
+                return intArrayOf()
             }
 
-            Log.v(Main.LOG_TAG, "HistogramView create histogram from ${result.totalStrikes.size} total strikes")
+            Log.v(Main.LOG_TAG, "HistogramView create histogram from ${result.strikes.size} total strikes")
             val referenceTime = result.referenceTime
 
             val binInterval = 5
             val binCount = parameters.intervalDuration / binInterval
             val histogram = IntArray(binCount)
 
-            result.totalStrikes.forEach { strike ->
+            result.strikes.forEach { strike ->
                 val binIndex = (binCount - 1) - ((referenceTime - strike.timestamp) / 1000 / 60 / binInterval).toInt()
                 if (binIndex in 0 until binCount)
                     histogram[binIndex]++
             }
-            this.histogram = histogram
-            return true
+            return histogram
         }
     }
 }

--- a/app/src/main/java/org/blitzortung/android/data/provider/blitzortung/BlitzortungHttpDataProvider.kt
+++ b/app/src/main/java/org/blitzortung/android/data/provider/blitzortung/BlitzortungHttpDataProvider.kt
@@ -178,11 +178,7 @@ class BlitzortungHttpDataProvider @Inject constructor(
                     }) { strikeMapBuilder.buildFromLine(it) }
 
             if (latestTime > 0L) {
-                resultVar = resultVar.copy(incrementalData = true)
-            }
-
-            if (latestTime > 0L) {
-                resultVar = resultVar.copy(incrementalData = true)
+                resultVar = resultVar.copy(updated = strikes.size)
                 val expireTime = resultVar.referenceTime - (intervalDuration - intervalOffset) * millisecondsPerMinute
                 this@BlitzortungHttpDataProvider.strikes = this@BlitzortungHttpDataProvider.strikes.filter { it.timestamp > expireTime }
                 this@BlitzortungHttpDataProvider.strikes += strikes
@@ -195,7 +191,7 @@ class BlitzortungHttpDataProvider @Inject constructor(
                 Log.v(Main.LOG_TAG, "BlitzortungHttpDataProvider.getStrikes() set latest time to $latestTime")
             }
 
-            resultVar = resultVar.copy(strikes = strikes, totalStrikes = this@BlitzortungHttpDataProvider.strikes, referenceTime = endTime)
+            resultVar = resultVar.copy(strikes = this@BlitzortungHttpDataProvider.strikes, referenceTime = endTime)
 
             return resultVar
         }

--- a/app/src/main/java/org/blitzortung/android/data/provider/result/ResultEvent.kt
+++ b/app/src/main/java/org/blitzortung/android/data/provider/result/ResultEvent.kt
@@ -26,12 +26,11 @@ import org.blitzortung.android.data.beans.Strike
 
 data class ResultEvent(
         val strikes: List<Strike>? = null,
-        val totalStrikes: List<Strike>? = null,
         val stations: List<Station>? = null,
         val rasterParameters: RasterParameters? = null,
         val histogram: IntArray? = null,
         val failed: Boolean = false,
-        val incrementalData: Boolean = false,
+        val updated: Int = -1,
         val referenceTime: Long = 0,
         val parameters: Parameters,
         val flags: Flags
@@ -47,13 +46,12 @@ data class ResultEvent(
             sb.append("FailedResult()")
         } else {
             sb.append("Result(")
-            val currentStrikes = strikes
-            sb.append(currentStrikes?.size ?: 0).append(" strikes, ")
+            sb.append(strikes?.size ?: 0).append(" strikes, ")
             sb.append(parameters)
             if (rasterParameters != null) {
                 sb.append(", ").append(rasterParameters)
             }
-            sb.append(", incrementalData=$incrementalData")
+            sb.append(", updated=$updated")
             sb.append(", referenceTime=$referenceTime")
             sb.append(")")
         }

--- a/app/src/main/java/org/blitzortung/android/map/overlay/RasterShape.kt
+++ b/app/src/main/java/org/blitzortung/android/map/overlay/RasterShape.kt
@@ -96,12 +96,8 @@ class RasterShape(private val center: IGeoPoint) : LightningShape {
     }
 
     private fun calculateAlphaValue(value: Float, minValue: Int, maxValue: Int, maxAlpha: Int, minAlpha: Int): Int {
-        val targetValue = coerceToRange((value - minValue) / (maxValue - minValue), 0.0f, 1.0f)
+        val targetValue = ((value - minValue) / (maxValue - minValue)).coerceIn(0.0f, 1.0f)
         return minAlpha + ((maxAlpha - minAlpha) * (1.0 - targetValue)).toInt()
-    }
-
-    private fun coerceToRange(value: Float, lowerBound: Float, upperBound: Float): Float {
-        return value.coerceIn(lowerBound, upperBound)
     }
 
     companion object {

--- a/app/src/test/java/org/blitzortung/android/alert/handler/AlertDataHandlerTest.kt
+++ b/app/src/test/java/org/blitzortung/android/alert/handler/AlertDataHandlerTest.kt
@@ -67,7 +67,7 @@ class AlertDataHandlerTest {
         strike = strike.copy(timestamp = thresholdTime)
         every { location.distanceTo(any()) } returns 2500f
 
-        val result = alertDataHandler.checkStrikes(arrayListOf(strike), location, parameters, now)
+        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)
 
         val sector = result.sectorWithClosestStrike
         assertThat(sector).isNotNull
@@ -82,7 +82,7 @@ class AlertDataHandlerTest {
         every { location.distanceTo(any()) } returns 2500f
         every { location.bearingTo(any()) } returns 90f
 
-        val result = alertDataHandler.checkStrikes(arrayListOf(strike), location, parameters, now)
+        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)
 
         val sector = result.sectorWithClosestStrike
         assertThat(sector).isNotNull
@@ -97,7 +97,7 @@ class AlertDataHandlerTest {
         every { location.distanceTo(any()) } returns 2500f
         every { location.bearingTo(any()) } returns 180f
 
-        val result = alertDataHandler.checkStrikes(arrayListOf(strike), location, parameters, now)
+        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)
 
         val sector = result.sectorWithClosestStrike
         assertThat(sector).isNotNull
@@ -111,7 +111,7 @@ class AlertDataHandlerTest {
         strike = strike.copy(timestamp = thresholdTime)
         every { location.distanceTo(any()) } returns 5000.1f
 
-        val result = alertDataHandler.checkStrikes(arrayListOf(strike), location, parameters, now)
+        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)
 
         assertThat(result.sectorWithClosestStrike).isNull()
         assertThat(rangeWithStrike(result)).isNull()
@@ -123,7 +123,7 @@ class AlertDataHandlerTest {
         every { location.distanceTo(any()) } returns 2500.1f
         every { location.bearingTo(any()) } returns -90f
 
-        val result = alertDataHandler.checkStrikes(listOf(strike), location, parameters, now)
+        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)
 
         assertThat(result.sectorWithClosestStrike).isNull()
         assertSectorAndRange(result, "N", 5f, beforeThresholdTime)
@@ -134,7 +134,7 @@ class AlertDataHandlerTest {
         strike = strike.copy(timestamp = beforeThresholdTime)
         every { location.distanceTo(any()) } returns 5000.1f
 
-        val result = alertDataHandler.checkStrikes(listOf(strike), location, parameters, now)
+        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)
 
         assertThat(result.sectorWithClosestStrike).isNull()
         assertThat(rangeWithStrike(result)).isNull()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 android.enableJetifier=true
 android.useAndroidX=true
-android.enableR8=true


### PR DESCRIPTION
Currently alert calculation considers the center of the raster areas.

As strikes may be located anywhere in the rectangle the rectangle dimensions should be considered when calculating the minimum distance.