### PR TITLE
Added fastlane metadata for F-Droid

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,21 @@
+Simple to use map based application, visualizing real time full area lightning data provided by the blitzortung.org lightning location network project. The current thunderstorm situation at your fingertips.
+
+<b>Features:</b>
+
+* realtime display of lightning data
+* display of historical lightning data of the last 24 hours
+* for regions Europe, North & South America, Asia, Africa and Australia/New Zealand
+* lightning strike time color coded
+* reduced data volume and fast response
+* current lightning strike time and lightning count
+* optional user location marker
+* alert function shows distance/direction of storms
+* background service for alerts
+* support for notifications, sound and vibration alarm
+* single stroke display for blitzortung.org participants
+
+Please visit <a href="https://www.blitzortung.org/">https://www.blitzortung.org</a> for more information regarding the community based lightning location project.
+
+The raster display ensures a fast performance of the application even if there is a very high thunderstorm activity. Blitzortung.org participants can visualize all stroke locations individually.
+
+If you would like to contribute to a translation of the software in your language, please do not hesitate to contact the author of the software.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+Get an overview of the current thunderstorm situation

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+Blitzortung Lightning Monitor

--- a/fastlane/metadata/android/pl/full_description.txt
+++ b/fastlane/metadata/android/pl/full_description.txt
@@ -1,0 +1,21 @@
+Prosta w użyciu aplikacja oparta na mapie, wizualizująca w czasie rzeczywistym dane dotyczące wyładowań atmosferycznych na całym obszarze, które są dostarczane przez projekt sieci wykrywania wyładowań atmosferycznych blitzortung.org. Aktualna sytuacja burzowa na wyciągnięcie ręki.
+
+<b>Cechy:</b>
+
+* wyświetlanie danych o wyładowaniach w czasie rzeczywistym
+* wyświetlanie danych historycznych o wyładowaniach atmosferycznych z ostatnich 24 godzin
+* dla obszarów Europy, Ameryki Północnej i Południowej, Azji, Afryki, Australii/Nowej Zelandii
+* czas uderzenia pioruna oznaczony kolorem
+* zmniejszona objętość danych i szybka reakcja
+* aktualny czas uderzenia pioruna i liczba piorunów
+* opcjonalny znacznik lokalizacji użytkownika
+* funkcja ostrzegania pokazująca odległość/kierunek burz
+* usługa w tle dla alarmów
+* obsługa powiadomień, alarmu dźwiękowego i z wibracją
+* wyświetlanie pojedynczych wyładowań dla uczestników blitzortung.org
+
+Odwiedź <a href="https://www.blitzortung.org/">https://www.blitzortung.org</a>, aby uzyskać więcej informacji na temat projektu.
+
+Wyświetlacz rastrowy zapewnia szybkie działanie aplikacji nawet w przypadku bardzo wysokiej aktywności burzowej. Uczestnicy Blitzortung.org mogą wizualizować każdą indywidualną lokalizację wyładowań.
+
+Jeśli chciałbyś/chciałabyś przyczynić się do tłumaczenia aplikacji na swój język, nie wahaj się skontaktować z autorem oprogramowania.

--- a/fastlane/metadata/android/pl/short_description.txt
+++ b/fastlane/metadata/android/pl/short_description.txt
@@ -1,0 +1,1 @@
+Uzyskaj wgląd w aktualną sytuację burzową

--- a/fastlane/metadata/android/pl/title.txt
+++ b/fastlane/metadata/android/pl/title.txt
@@ -1,0 +1,1 @@
+Blitzortung - wykrywanie piorunów


### PR DESCRIPTION
Hi,

In this pull request, I'm adding support for Fastlane metadata, that is used by F-Droid to create app descriptions. This way, the app can have descriptions in multiple languages (I've added Polish next to English) and also screenshots, changelogs or videos. 
The structure is based on this F-Droid article: <https://f-droid.org/en/docs/All_About_Descriptions_Graphics_and_Screenshots/#fastlane-structure>.

After merging this pull request, as I understand F-Droid docs, the description will need to be removed from [the metadata file on F-Droid data repo](https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/org.blitzortung.android.app.yml) and probably all summary.txt files there.