### PR TITLE
Automatic switch between local and global data

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.blitzortung.android.app"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 325
-        versionName '2.2.6'
+        versionCode 326
+        versionName '2.3.0beta1'
         multiDexEnabled false
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.blitzortung.android.app"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 326
-        versionName '2.3.0beta1'
+        versionCode 327
+        versionName '2.3-beta1'
         multiDexEnabled false
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/org/blitzortung/android/app/Main.kt
+++ b/app/src/main/java/org/blitzortung/android/app/Main.kt
@@ -82,7 +82,6 @@ import org.blitzortung.android.util.isAtLeast
 import org.osmdroid.config.Configuration
 import org.osmdroid.tileprovider.util.StorageUtils
 import org.osmdroid.util.GeoPoint
-import java.lang.Thread.sleep
 import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import kotlin.math.roundToInt

--- a/app/src/main/java/org/blitzortung/android/app/Main.kt
+++ b/app/src/main/java/org/blitzortung/android/app/Main.kt
@@ -30,8 +30,6 @@ import android.location.LocationManager.*
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.os.PowerManager
 import android.preference.PreferenceManager
 import android.provider.Settings
@@ -421,7 +419,6 @@ class Main : FragmentActivity(), OnSharedPreferenceChangeListener {
             mapView.zoomLevelDouble
         }
 
-        Log.d(LOG_TAG, "Main.animateAndZoomTo() start animation ${mapView.zoomLevelDouble}")
         mapView.controller.animateTo(GeoPoint(latitude, longitude), targetZoomLevel, OwnMapView.DEFAULT_ZOOM_SPEED)
     }
 

--- a/app/src/main/java/org/blitzortung/android/app/Main.kt
+++ b/app/src/main/java/org/blitzortung/android/app/Main.kt
@@ -30,6 +30,8 @@ import android.location.LocationManager.*
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.os.PowerManager
 import android.preference.PreferenceManager
 import android.provider.Settings
@@ -82,6 +84,7 @@ import org.blitzortung.android.util.isAtLeast
 import org.osmdroid.config.Configuration
 import org.osmdroid.tileprovider.util.StorageUtils
 import org.osmdroid.util.GeoPoint
+import java.lang.Thread.sleep
 import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import kotlin.math.roundToInt
@@ -367,6 +370,7 @@ class Main : FragmentActivity(), OnSharedPreferenceChangeListener {
         }
 
         with(binding.histogramView) {
+            mapFragment = this@Main.mapFragment
             setStrikesOverlay(strikeListOverlay)
             setOnClickListener {
                 val currentResult = currentResult
@@ -417,6 +421,7 @@ class Main : FragmentActivity(), OnSharedPreferenceChangeListener {
             mapView.zoomLevelDouble
         }
 
+        Log.d(LOG_TAG, "Main.animateAndZoomTo() start animation ${mapView.zoomLevelDouble}")
         mapView.controller.animateTo(GeoPoint(latitude, longitude), targetZoomLevel, OwnMapView.DEFAULT_ZOOM_SPEED)
     }
 

--- a/app/src/main/java/org/blitzortung/android/app/view/HistogramView.kt
+++ b/app/src/main/java/org/blitzortung/android/app/view/HistogramView.kt
@@ -112,13 +112,13 @@ class HistogramView @JvmOverloads constructor(
             var topCoordinate = padding
 
             val bb = mapFragment.mapView.boundingBox
-            val text = "%.2f..%.2f - %.2f..%.2f".format(bb.lonWest, bb.lonEast, bb.latSouth, bb.latNorth)
+            val text = "%.2f..%.2f  %.2f..%.2f".format(bb.lonWest, bb.lonEast, bb.latSouth, bb.latNorth)
             canvas.drawText(text, width - padding, topCoordinate + textSize / 1.2f * SMALL_TEXT_SCALE, smallTextPaint)
             topCoordinate += (textSize + padding) * SMALL_TEXT_SCALE
 
             val gridParameters = gridParameters
             if (gridParameters != null) {
-                val text = "%.2f..%.2f - %.2f..%.2f".format(gridParameters.longitudeStart, gridParameters.longitudeEnd, gridParameters.latitudeEnd, gridParameters.latitudeStart)
+                val text = "%.2f..%.2f  %.2f..%.2f".format(gridParameters.longitudeStart, gridParameters.longitudeEnd, gridParameters.latitudeEnd, gridParameters.latitudeStart)
                 canvas.drawText(text, width - padding, topCoordinate + textSize / 1.2f * SMALL_TEXT_SCALE, smallTextPaint)
                 topCoordinate += (textSize + padding) * SMALL_TEXT_SCALE
             }

--- a/app/src/main/java/org/blitzortung/android/app/view/LegendView.kt
+++ b/app/src/main/java/org/blitzortung/android/app/view/LegendView.kt
@@ -25,12 +25,10 @@ import android.graphics.Paint
 import android.graphics.RectF
 import android.util.AttributeSet
 import org.blitzortung.android.app.R
-import org.blitzortung.android.map.MapFragment
 import org.blitzortung.android.map.overlay.StrikeListOverlay
 import org.blitzortung.android.util.TabletAwareView
 import kotlin.math.max
 import kotlin.math.min
-import kotlin.math.round
 
 class LegendView @JvmOverloads constructor(
     context: Context,

--- a/app/src/main/java/org/blitzortung/android/app/view/LegendView.kt
+++ b/app/src/main/java/org/blitzortung/android/app/view/LegendView.kt
@@ -189,7 +189,6 @@ class LegendView @JvmOverloads constructor(
         get() {
             val regionNumber = strikesOverlay!!.parameters.region
 
-
             for ((index, regionNumberString) in resources.getStringArray(R.array.regions_values).withIndex()) {
                 if (regionNumber == Integer.parseInt(regionNumberString)) {
                     return resources.getStringArray(R.array.regions)[index]

--- a/app/src/main/java/org/blitzortung/android/app/view/LegendView.kt
+++ b/app/src/main/java/org/blitzortung/android/app/view/LegendView.kt
@@ -25,10 +25,12 @@ import android.graphics.Paint
 import android.graphics.RectF
 import android.util.AttributeSet
 import org.blitzortung.android.app.R
+import org.blitzortung.android.map.MapFragment
 import org.blitzortung.android.map.overlay.StrikeListOverlay
 import org.blitzortung.android.util.TabletAwareView
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.round
 
 class LegendView @JvmOverloads constructor(
     context: Context,
@@ -64,7 +66,6 @@ class LegendView @JvmOverloads constructor(
     var strikesOverlay: StrikeListOverlay? = null
 
     init {
-
         setBackgroundColor(Color.TRANSPARENT)
     }
 
@@ -189,6 +190,7 @@ class LegendView @JvmOverloads constructor(
     private val regionName: String
         get() {
             val regionNumber = strikesOverlay!!.parameters.region
+
 
             for ((index, regionNumberString) in resources.getStringArray(R.array.regions_values).withIndex()) {
                 if (regionNumber == Integer.parseInt(regionNumberString)) {

--- a/app/src/main/java/org/blitzortung/android/data/Parameters.kt
+++ b/app/src/main/java/org/blitzortung/android/data/Parameters.kt
@@ -25,6 +25,7 @@ import java.io.Serializable
 data class Parameters(
     val region: Int = -1,
     val gridSize: Int = 0,
+    val dataArea: Int = 5,
     val interval: TimeInterval = TimeInterval(),
     val countThreshold: Int = 0,
     val localReference: LocalReference? = null

--- a/app/src/main/java/org/blitzortung/android/data/beans/GridParameters.kt
+++ b/app/src/main/java/org/blitzortung/android/data/beans/GridParameters.kt
@@ -38,6 +38,10 @@ data class GridParameters(
 
     val rectCenterLatitude: Double = latitudeStart - latitudeDelta * latitudeBins / 2.0
 
+    val longitudeEnd: Double = longitudeStart + longitudeDelta * longitudeBins
+
+    val latitudeEnd: Double = latitudeStart - latitudeDelta * latitudeBins
+
     fun getCenterLongitude(offset: Int): Double {
         return longitudeStart + longitudeDelta * (offset + 0.5)
     }

--- a/app/src/main/java/org/blitzortung/android/data/provider/LocalData.kt
+++ b/app/src/main/java/org/blitzortung/android/data/provider/LocalData.kt
@@ -1,30 +1,108 @@
 package org.blitzortung.android.data.provider
 
 import android.location.Location
+import android.util.Log
+import org.blitzortung.android.app.Main.Companion.LOG_TAG
 import org.blitzortung.android.data.LocalReference
 import org.blitzortung.android.data.Parameters
+import org.blitzortung.android.data.beans.GridParameters
+import org.osmdroid.util.BoundingBox
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.max
+import kotlin.math.round
+
+private const val MIN_DATA_AREA = 5
+
+private const val LOCAL_DATA_AREA = MIN_DATA_AREA
+
+private const val DATA_AREA_SCALING = 0.5
 
 @Singleton
 class LocalData @Inject constructor() {
+
+    var localReference: LocalReference? = null
+    var dataArea: Int = LOCAL_DATA_AREA
+    var gridParameters: GridParameters? = null
+
     fun updateParameters(parameters: Parameters, location: Location?): Parameters {
-        return if (parameters.region == LOCAL_REGION) {
-            if (location != null) {
-                val x = calculateLocalRegion(location.longitude)
-                val y = calculateLocalRegion(location.latitude)
-                parameters.copy(localReference = LocalReference(x, y))
-            } else {
-                parameters.copy(region = GLOBAL_REGION)
+        return when (parameters.region) {
+            LOCAL_REGION -> {
+                if (location != null) {
+                    Log.d(LOG_TAG, "LocalData.updateParameters() local")
+                    val x = calculateLocalCoordinate(location.longitude)
+                    val y = calculateLocalCoordinate(location.latitude)
+                    parameters.copy(localReference = LocalReference(x, y), dataArea = LOCAL_DATA_AREA)
+                } else {
+                    Log.d(LOG_TAG, "LocalData.updateParameters() local -> global")
+                    parameters.copy(region = GLOBAL_REGION, localReference = null, dataArea = LOCAL_DATA_AREA)
+                }
             }
-        } else {
-            parameters
+
+            GLOBAL_REGION -> {
+                if (localReference != null && parameters.gridSize <= 10000) {
+                    Log.d(LOG_TAG, "LocalData.updateParameters() global -> local")
+                    parameters.copy(region = LOCAL_REGION, localReference = localReference, dataArea = dataArea)
+                } else {
+                    Log.d(LOG_TAG, "LocalData.updateParameters() global")
+                    parameters.copy(region = GLOBAL_REGION, localReference = null, dataArea = LOCAL_DATA_AREA)
+                }
+            }
+
+            else -> {
+                parameters
+            }
         }
     }
 
-    private fun calculateLocalRegion(value: Double): Int {
-        return (value / 5).toInt() - if (value < 0) 1 else 0
+    fun update(boundingBox: BoundingBox, force: Boolean = false): Boolean {
+        val dataArea =
+            max(
+                MIN_DATA_AREA,
+                round(DATA_AREA_SCALING * max(boundingBox.longitudeSpanWithDateLine, boundingBox.latitudeSpan)).toInt()
+            )
+        val xPos = calculateLocalCoordinate(boundingBox.centerLongitude, dataArea)
+        val yPos = calculateLocalCoordinate(boundingBox.centerLatitude, dataArea)
+        val localReference = LocalReference(xPos, yPos)
+
+        val gridParameters = gridParameters
+        val isOutside = if (gridParameters == null) false else this@LocalData.isOutside(boundingBox, gridParameters)
+        val isChanged = this.dataArea != dataArea || this.localReference != localReference
+        return if (
+            gridParameters != null && isOutside && isChanged ||
+            gridParameters == null && isChanged ||
+            force
+        ) {
+            Log.d(
+                LOG_TAG,
+                "LocalData.update() $xPos, $yPos ($dataArea) from center ${round(boundingBox.centerLongitude * 100) / 100}, ${
+                    round(boundingBox.centerLatitude * 100) / 100
+                } -> ${xPos * dataArea}..${(xPos + 1) * dataArea} ${yPos * dataArea}..${(yPos + 1) * dataArea}, span: ${
+                    round(boundingBox.longitudeSpanWithDateLine * 100) / 100
+                }, ${round(boundingBox.latitudeSpan * 100) / 100} "
+            )
+            this.dataArea = dataArea
+            this.localReference = localReference
+            true
+        } else {
+            false
+        }
     }
+
+    private fun isOutside(boundingBox: BoundingBox, gridParameters: GridParameters): Boolean {
+        return boundingBox.lonWest < gridParameters.longitudeStart ||
+                boundingBox.lonEast > gridParameters.longitudeEnd ||
+                boundingBox.latNorth > gridParameters.latitudeStart ||
+                boundingBox.latSouth < gridParameters.latitudeEnd
+    }
+
+    fun storeResult(gridParameters: GridParameters?) {
+        this.gridParameters = gridParameters
+    }
+}
+
+fun calculateLocalCoordinate(value: Double, dataArea: Int = LOCAL_DATA_AREA): Int {
+    return (value / dataArea).toInt() - if (value < 0) 1 else 0
 }
 
 internal const val LOCAL_REGION = -1

--- a/app/src/main/java/org/blitzortung/android/data/provider/standard/JsonRpcData.kt
+++ b/app/src/main/java/org/blitzortung/android/data/provider/standard/JsonRpcData.kt
@@ -19,6 +19,7 @@ class JsonRpcData(
         val countThreshold = parameters.countThreshold
         val region = parameters.region
         val localReference = parameters.localReference
+        val dataArea = parameters.dataArea
 
         return when (region) {
             GLOBAL_REGION -> {
@@ -48,7 +49,8 @@ class JsonRpcData(
                     gridSize,
                     intervalDuration,
                     intervalOffset,
-                    countThreshold
+                    countThreshold,
+                    dataArea,
                 )
             }
 

--- a/app/src/main/java/org/blitzortung/android/map/OwnMapView.kt
+++ b/app/src/main/java/org/blitzortung/android/map/OwnMapView.kt
@@ -18,6 +18,7 @@
 
 package org.blitzortung.android.map
 
+import android.animation.ValueAnimator
 import android.content.Context
 import android.content.DialogInterface
 import android.graphics.Point
@@ -28,11 +29,15 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import androidx.appcompat.app.AlertDialog
+import androidx.core.animation.doOnCancel
+import androidx.core.animation.doOnEnd
 import androidx.core.view.GestureDetectorCompat
 import org.blitzortung.android.app.Main
+import org.blitzortung.android.app.Main.Companion.LOG_TAG
 import org.blitzortung.android.app.R
 import org.blitzortung.android.app.view.PreferenceKey
 import org.blitzortung.android.location.LocationHandler
+import org.osmdroid.views.MapController
 import org.osmdroid.views.MapView
 
 
@@ -101,6 +106,15 @@ class OwnMapView(context: Context) : MapView(context) {
     }
 
     val popup: View by lazy { LayoutInflater.from(context).inflate(R.layout.popup, this, false) }
+
+    private val animatorField = MapController::class.java.getDeclaredField("mCurrentAnimator")
+
+    fun animator(): ValueAnimator? {
+        if (!isAnimating) return null
+
+        animatorField.isAccessible = true
+        return animatorField.get(controller) as ValueAnimator
+    }
 
     companion object {
         const val DEFAULT_ZOOM_SPEED = 500L

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@ Polish by Jakub Świątkiewicz (kuba.dex@gmail.com), Agnieszka Cieślak (aga_04@
 Italian by Michele Locati (michele@locati.it)\n
 Russian by Ivan Karev (karev.ivan@gmail.com)\n
     </string>
-    <string name="copyright" translatable="false">© 2011–2024, Andreas Würl</string>
+    <string name="copyright" translatable="false">© 2011–2025, Andreas Würl</string>
     <string name="project_email" translatable="false">blitzortung@tryb.de</string>
     <string name="legend">Legend</string>
     <string name="legend_grid">Grid</string>

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <changelog>
     <release
+        versionName="2.3"
+        versionCode="327">
+        <feature>Dynamic local data retrieval</feature>
+    </release>
+    <release
         versionName="2.2"
         versionCode="293">
         <feature>Time slider replaces buttons</feature>


### PR DESCRIPTION
In order to save bandwith global data should only be limited for higher grid sizes (25km raster and above) the detailed data will be retrieved in a mode similar to the existing local data mode which will be updated when panning and zooming the map.