### PR TITLE
Dynamic local data mode (2.3 beta)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.blitzortung.android.app"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 327
-        versionName '2.3-beta1'
+        versionCode 328
+        versionName '2.3-beta2'
         multiDexEnabled false
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.blitzortung.android.app"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 325
-        versionName '2.2.6'
+        versionCode 327
+        versionName '2.3-beta1'
         multiDexEnabled false
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/org/blitzortung/android/alert/handler/AlertDataHandler.kt
+++ b/app/src/main/java/org/blitzortung/android/alert/handler/AlertDataHandler.kt
@@ -20,9 +20,11 @@ package org.blitzortung.android.alert.handler
 
 import android.content.res.Resources
 import android.location.Location
+import android.util.Log
 import org.blitzortung.android.alert.AlertParameters
 import org.blitzortung.android.alert.AlertResult
 import org.blitzortung.android.alert.data.AlertSector
+import org.blitzortung.android.app.Main.Companion.LOG_TAG
 import org.blitzortung.android.data.beans.GridElement
 import org.blitzortung.android.data.beans.GridParameters
 import org.blitzortung.android.data.beans.Strike
@@ -39,7 +41,13 @@ open class AlertDataHandler @Inject internal constructor(
     fun checkStrikes(
         strikes: Strikes, location: Location, parameters: AlertParameters,
         referenceTime: Long = System.currentTimeMillis()
-    ): AlertResult {
+    ): AlertResult? {
+        val gridParameters: GridParameters? = strikes.gridParameters
+        if (gridParameters != null && !gridParameters.isGlobal && !gridParameters.contains(location.longitude, location.latitude, 0.2)) {
+            Log.v(LOG_TAG, "Location $location is not in grid ${gridParameters.longitudeInterval} + ${gridParameters.latitudeInterval}")
+            return null
+        }
+
         val sectors = createSectors(parameters)
 
         val thresholdTime = referenceTime - parameters.alarmInterval
@@ -54,7 +62,7 @@ open class AlertDataHandler @Inject internal constructor(
                 checkStrike(
                     alertSector,
                     strike,
-                    strikes.gridParameters,
+                    gridParameters,
                     parameters.measurementSystem,
                     location,
                     thresholdTime

--- a/app/src/main/java/org/blitzortung/android/app/Main.kt
+++ b/app/src/main/java/org/blitzortung/android/app/Main.kt
@@ -367,6 +367,7 @@ class Main : FragmentActivity(), OnSharedPreferenceChangeListener {
         }
 
         with(binding.histogramView) {
+            mapFragment = this@Main.mapFragment
             setStrikesOverlay(strikeListOverlay)
             setOnClickListener {
                 val currentResult = currentResult

--- a/app/src/main/java/org/blitzortung/android/app/view/HistogramView.kt
+++ b/app/src/main/java/org/blitzortung/android/app/view/HistogramView.kt
@@ -25,11 +25,17 @@ import android.graphics.RectF
 import android.util.AttributeSet
 import android.util.Log
 import org.blitzortung.android.app.Main
+import org.blitzortung.android.app.Main.Companion.LOG_TAG
 import org.blitzortung.android.app.R
+import org.blitzortung.android.data.Parameters
+import org.blitzortung.android.data.beans.GridParameters
 import org.blitzortung.android.data.provider.result.ResultEvent
+import org.blitzortung.android.map.MapFragment
 import org.blitzortung.android.map.overlay.StrikeListOverlay
 import org.blitzortung.android.protocol.Event
 import org.blitzortung.android.util.TabletAwareView
+
+private const val SMALL_TEXT_SCALE = 0.6f
 
 class HistogramView @JvmOverloads constructor(
     context: Context,
@@ -40,10 +46,14 @@ class HistogramView @JvmOverloads constructor(
     private val backgroundPaint: Paint = Paint(Paint.ANTI_ALIAS_FLAG)
     private val foregroundPaint: Paint = Paint(Paint.ANTI_ALIAS_FLAG)
     private val textPaint: Paint
+    private val smallTextPaint: Paint
     private val defaultForegroundColor: Int
     private val backgroundRect: RectF
     private var strikesOverlay: StrikeListOverlay? = null
     private var histogram: IntArray? = null
+    private var gridParameters: GridParameters? = null
+    private var parameters: Parameters? = null
+    lateinit var mapFragment: MapFragment
 
     val dataConsumer = { event: Event ->
         if (event is ResultEvent) {
@@ -59,6 +69,11 @@ class HistogramView @JvmOverloads constructor(
         textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             color = defaultForegroundColor
             textSize = this@HistogramView.textSize
+            textAlign = Paint.Align.RIGHT
+        }
+        smallTextPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = defaultForegroundColor
+            textSize = this@HistogramView.textSize * SMALL_TEXT_SCALE
             textAlign = Paint.Align.RIGHT
         }
 
@@ -94,13 +109,29 @@ class HistogramView @JvmOverloads constructor(
             backgroundRect.set(0f, 0f, width.toFloat(), height.toFloat())
             canvas.drawRect(backgroundRect, backgroundPaint)
 
+            var topCoordinate = padding
+
+            val bb = mapFragment.mapView.boundingBox
+            val text = "%.2f..%.2f  %.2f..%.2f".format(bb.lonWest, bb.lonEast, bb.latSouth, bb.latNorth)
+            canvas.drawText(text, width - padding, topCoordinate + textSize / 1.2f * SMALL_TEXT_SCALE, smallTextPaint)
+            topCoordinate += (textSize + padding) * SMALL_TEXT_SCALE
+
+            val gridParameters = gridParameters
+            if (gridParameters != null) {
+                val text = "%.2f..%.2f  %.2f..%.2f".format(gridParameters.longitudeStart, gridParameters.longitudeEnd, gridParameters.latitudeEnd, gridParameters.latitudeStart)
+                canvas.drawText(text, width - padding, topCoordinate + textSize / 1.2f * SMALL_TEXT_SCALE, smallTextPaint)
+                topCoordinate += (textSize + padding) * SMALL_TEXT_SCALE
+            }
+
             val maximumCount = histogram.maxOrNull() ?: 0
 
             canvas.drawText(
                 "%.1f/%s _".format(
                     maximumCount.toFloat() / minutesPerBin, resources.getString(R.string.unit_minute)
-                ), width - 2 * padding, padding + textSize / 1.2f, textPaint
+                ), width - 2 * padding, topCoordinate + textSize / 1.2f, textPaint
             )
+
+            topCoordinate += textSize
 
             val ymax = if (maximumCount == 0) 1 else maximumCount
 
@@ -108,7 +139,8 @@ class HistogramView @JvmOverloads constructor(
             val xd = (width - 2 * padding) / (histogram.size - 1)
 
             val y0 = height - padding
-            val yd = (height - 2 * padding - textSize) / ymax
+            Log.v(LOG_TAG, "HistogramView.onDraw() height: $height, top $topCoordinate")
+            val yd = (height - topCoordinate - padding) / ymax
 
             foregroundPaint.strokeWidth = 5f
             for (i in 0 until histogram.size - 1) {
@@ -140,6 +172,8 @@ class HistogramView @JvmOverloads constructor(
             histogram = null
         } else {
             val histogram = dataEvent.histogram
+            gridParameters = dataEvent.gridParameters
+            parameters = dataEvent.parameters
 
             val hasHistogram = histogram != null && histogram.isNotEmpty()
 

--- a/app/src/main/java/org/blitzortung/android/app/view/LegendView.kt
+++ b/app/src/main/java/org/blitzortung/android/app/view/LegendView.kt
@@ -64,7 +64,6 @@ class LegendView @JvmOverloads constructor(
     var strikesOverlay: StrikeListOverlay? = null
 
     init {
-
         setBackgroundColor(Color.TRANSPARENT)
     }
 

--- a/app/src/main/java/org/blitzortung/android/data/MainDataHandler.kt
+++ b/app/src/main/java/org/blitzortung/android/data/MainDataHandler.kt
@@ -473,9 +473,9 @@ class MainDataHandler @Inject constructor(
         }
 
     private fun addUpdateAfterAnimationListener(mapView: OwnMapView) {
-        val animator = mapView.animator()!!
+        val animator = mapView.animator()
 
-        if (!animator.listeners.contains(animatorListener)) {
+        if (animator != null && !animator.listeners.contains(animatorListener)) {
             animator.addListener(animatorListener)
         }
     }

--- a/app/src/main/java/org/blitzortung/android/data/MainDataHandler.kt
+++ b/app/src/main/java/org/blitzortung/android/data/MainDataHandler.kt
@@ -146,12 +146,6 @@ class MainDataHandler @Inject constructor(
         if (updatesEnabled) {
             sendEvent(REQUEST_STARTED_EVENT)
 
-            var updateParticipants = false
-            if (updateTargets.contains(DataChannel.PARTICIPANTS)) {
-                if (dataProvider!!.type == DataProviderType.HTTP || !dataMode.grid) {
-                    updateParticipants = true
-                }
-            }
             updateUsingCache()
         }
     }

--- a/app/src/main/java/org/blitzortung/android/data/MainDataHandler.kt
+++ b/app/src/main/java/org/blitzortung/android/data/MainDataHandler.kt
@@ -18,6 +18,8 @@
 
 package org.blitzortung.android.data
 
+import android.animation.Animator
+import android.animation.Animator.AnimatorListener
 import android.content.Context
 import android.content.SharedPreferences
 import android.location.Location
@@ -40,11 +42,13 @@ import org.blitzortung.android.data.provider.result.RequestStartedEvent
 import org.blitzortung.android.data.provider.result.ResultEvent
 import org.blitzortung.android.data.provider.result.StatusEvent
 import org.blitzortung.android.location.LocationEvent
+import org.blitzortung.android.map.OwnMapView
 import org.blitzortung.android.protocol.ConsumerContainer
 import org.blitzortung.android.util.Period
 import org.osmdroid.events.MapListener
 import org.osmdroid.events.ScrollEvent
 import org.osmdroid.events.ZoomEvent
+import org.osmdroid.util.BoundingBox
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
@@ -193,6 +197,9 @@ class MainDataHandler @Inject constructor(
         }
 
     private fun sendEvent(dataEvent: DataEvent) {
+        if (dataEvent is ResultEvent) {
+            localData.storeResult(dataEvent.gridParameters)
+        }
         if (dataEvent is ResultEvent && dataEvent.flags.storeResult) {
             dataConsumerContainer.storeAndBroadcast(dataEvent)
         } else {
@@ -408,23 +415,46 @@ class MainDataHandler @Inject constructor(
     }
 
     override fun onScroll(event: ScrollEvent?): Boolean {
-        return false
-    }
-
-    override fun onZoom(event: ZoomEvent?): Boolean {
         return if (event != null) {
-            updateAutoGridSize(event.zoomLevel)
+            val mapView = event.source as OwnMapView
+            val updated = updateLocation(mapView.boundingBox)
+            ensureUpdate(updated, mapView)
         } else {
             false
         }
     }
 
+    override fun onZoom(event: ZoomEvent?): Boolean {
+        return if (event != null) {
+            val mapView = event.source as OwnMapView
+            val updateAutoGridSize = updateAutoGridSize(event.zoomLevel)
+            val updateLocation = updateLocation(mapView.boundingBox, updateAutoGridSize)
+            val updated = updateLocation || updateAutoGridSize
+            ensureUpdate(updated, mapView)
+        } else {
+            false
+        }
+    }
+
+    private fun ensureUpdate(updated: Boolean, mapView: OwnMapView): Boolean {
+        if (updated) {
+            if (mapView.isAnimating) {
+                addUpdateAfterAnimationListener(mapView)
+            } else {
+                updateData()
+            }
+        }
+        return updated
+    }
+
+    fun updateLocation(boundingBox: BoundingBox, force: Boolean = false): Boolean = localData.update(boundingBox, force)
+
     fun updateAutoGridSize(zoomLevel: Double): Boolean =
         if (autoGridSize) {
             val gridSize = when {
                 zoomLevel >= 8f -> 5000
-                zoomLevel in 6f..8f -> 10000
-                zoomLevel in 4f..6f -> 25000
+                zoomLevel in 5.5f..8f -> 10000
+                zoomLevel in 4f..5.5f -> 25000
                 zoomLevel in 2f..4f -> 50000
                 else -> 100000
             }
@@ -434,7 +464,6 @@ class MainDataHandler @Inject constructor(
                     "MainDataHandler.updateAutoGridSize() $zoomLevel : ${parameters.gridSize} -> $gridSize"
                 )
                 parameters = parameters.copy(gridSize = gridSize)
-                updateData()
                 true
             } else {
                 false
@@ -443,6 +472,29 @@ class MainDataHandler @Inject constructor(
             false
         }
 
+    private fun addUpdateAfterAnimationListener(mapView: OwnMapView) {
+        val animator = mapView.animator()!!
+
+        if (!animator.listeners.contains(animatorListener)) {
+            animator.addListener(animatorListener)
+        }
+    }
+
+    private val animatorListener = object : AnimatorListener {
+        override fun onAnimationStart(animation: Animator) {
+        }
+
+        override fun onAnimationEnd(animation: Animator) {
+            this@MainDataHandler.updateData()
+        }
+
+        override fun onAnimationCancel(animation: Animator) {
+            this@MainDataHandler.updateData()
+        }
+
+        override fun onAnimationRepeat(animation: Animator) {
+        }
+    }
 
     fun calculateTotalCacheSize(): CacheSize = cache.calculateTotalSize()
 }

--- a/app/src/main/java/org/blitzortung/android/data/Parameters.kt
+++ b/app/src/main/java/org/blitzortung/android/data/Parameters.kt
@@ -25,6 +25,7 @@ import java.io.Serializable
 data class Parameters(
     val region: Int = -1,
     val gridSize: Int = 0,
+    val dataArea: Int = 5,
     val interval: TimeInterval = TimeInterval(),
     val countThreshold: Int = 0,
     val localReference: LocalReference? = null

--- a/app/src/main/java/org/blitzortung/android/data/beans/GridParameters.kt
+++ b/app/src/main/java/org/blitzortung/android/data/beans/GridParameters.kt
@@ -50,9 +50,11 @@ data class GridParameters(
         return latitudeStart - latitudeDelta * (offset + 0.5)
     }
 
-    private val rectLongitudeDelta: Double = longitudeDelta * longitudeBins
+    val longitudeInterval: Double = longitudeDelta * longitudeBins
 
-    private val rectLatitudeDelta: Double = latitudeDelta * latitudeBins
+    val latitudeInterval: Double = latitudeDelta * latitudeBins
+
+    val isGlobal = longitudeInterval > 350 && latitudeInterval > 170
 
     fun getRect(projection: Projection): RectF {
         var leftTop = Point()
@@ -60,8 +62,8 @@ data class GridParameters(
             Coordsys.toMapCoords(longitudeStart, latitudeStart), leftTop
         )
         var bottomRight = Point()
-        val longitudeEnd = longitudeStart + rectLongitudeDelta
-        val latitudeEnd = latitudeStart - rectLatitudeDelta
+        val longitudeEnd = longitudeStart + longitudeInterval
+        val latitudeEnd = latitudeStart - latitudeInterval
         bottomRight = projection.toPixels(
             Coordsys.toMapCoords(
                 longitudeEnd,
@@ -71,5 +73,11 @@ data class GridParameters(
 
         // Log.d(Main.LOG_TAG, "GridParameters.getRect() $longitudeStart - $longitudeEnd ($longitudeDelta, #$longitudeBins) $latitudeEnd - $latitudeStart ($latitudeDelta, #$latitudeBins)")
         return RectF(leftTop.x.toFloat(), leftTop.y.toFloat(), bottomRight.x.toFloat(), bottomRight.y.toFloat())
+    }
+
+    fun contains(longitude: Double, latitude: Double, inset: Double = 0.0): Boolean {
+        val inLongitude = longitude in longitudeStart + inset..longitudeEnd - inset
+        val inLatitude = latitude in latitudeStart - latitudeDelta * latitudeBins + inset .. latitudeStart - inset
+        return inLongitude && inLatitude
     }
 }

--- a/app/src/main/java/org/blitzortung/android/data/beans/GridParameters.kt
+++ b/app/src/main/java/org/blitzortung/android/data/beans/GridParameters.kt
@@ -38,6 +38,10 @@ data class GridParameters(
 
     val rectCenterLatitude: Double = latitudeStart - latitudeDelta * latitudeBins / 2.0
 
+    val longitudeEnd: Double = longitudeStart + longitudeDelta * longitudeBins
+
+    val latitudeEnd: Double = latitudeStart - latitudeDelta * latitudeBins
+
     fun getCenterLongitude(offset: Int): Double {
         return longitudeStart + longitudeDelta * (offset + 0.5)
     }

--- a/app/src/main/java/org/blitzortung/android/data/provider/LocalData.kt
+++ b/app/src/main/java/org/blitzortung/android/data/provider/LocalData.kt
@@ -1,30 +1,108 @@
 package org.blitzortung.android.data.provider
 
 import android.location.Location
+import android.util.Log
+import org.blitzortung.android.app.Main.Companion.LOG_TAG
 import org.blitzortung.android.data.LocalReference
 import org.blitzortung.android.data.Parameters
+import org.blitzortung.android.data.beans.GridParameters
+import org.osmdroid.util.BoundingBox
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.max
+import kotlin.math.round
+
+private const val MIN_DATA_AREA = 5
+
+private const val LOCAL_DATA_AREA = MIN_DATA_AREA
+
+private const val DATA_AREA_SCALING = 0.5
 
 @Singleton
 class LocalData @Inject constructor() {
+
+    var localReference: LocalReference? = null
+    var dataArea: Int = LOCAL_DATA_AREA
+    var gridParameters: GridParameters? = null
+
     fun updateParameters(parameters: Parameters, location: Location?): Parameters {
-        return if (parameters.region == LOCAL_REGION) {
-            if (location != null) {
-                val x = calculateLocalRegion(location.longitude)
-                val y = calculateLocalRegion(location.latitude)
-                parameters.copy(localReference = LocalReference(x, y))
-            } else {
-                parameters.copy(region = GLOBAL_REGION)
+        return when (parameters.region) {
+            LOCAL_REGION -> {
+                if (location != null) {
+                    Log.d(LOG_TAG, "LocalData.updateParameters() local")
+                    val x = calculateLocalCoordinate(location.longitude)
+                    val y = calculateLocalCoordinate(location.latitude)
+                    parameters.copy(localReference = LocalReference(x, y), dataArea = LOCAL_DATA_AREA)
+                } else {
+                    Log.d(LOG_TAG, "LocalData.updateParameters() local -> global")
+                    parameters.copy(region = GLOBAL_REGION, localReference = null, dataArea = LOCAL_DATA_AREA)
+                }
             }
-        } else {
-            parameters
+
+            GLOBAL_REGION -> {
+                if (localReference != null && parameters.gridSize <= 10000) {
+                    Log.d(LOG_TAG, "LocalData.updateParameters() global -> local")
+                    parameters.copy(region = LOCAL_REGION, localReference = localReference, dataArea = dataArea)
+                } else {
+                    Log.d(LOG_TAG, "LocalData.updateParameters() global")
+                    parameters.copy(region = GLOBAL_REGION, localReference = null, dataArea = LOCAL_DATA_AREA)
+                }
+            }
+
+            else -> {
+                parameters
+            }
         }
     }
 
-    private fun calculateLocalRegion(value: Double): Int {
-        return (value / 5).toInt() - if (value < 0) 1 else 0
+    fun update(boundingBox: BoundingBox, force: Boolean = false): Boolean {
+        val dataArea =
+            max(
+                MIN_DATA_AREA,
+                round(DATA_AREA_SCALING * max(boundingBox.longitudeSpanWithDateLine, boundingBox.latitudeSpan)).toInt()
+            )
+        val xPos = calculateLocalCoordinate(boundingBox.centerLongitude, dataArea)
+        val yPos = calculateLocalCoordinate(boundingBox.centerLatitude, dataArea)
+        val localReference = LocalReference(xPos, yPos)
+
+        val gridParameters = gridParameters
+        val isOutside = if (gridParameters == null) false else this@LocalData.isOutside(boundingBox, gridParameters)
+        val isChanged = this.dataArea != dataArea || this.localReference != localReference
+        return if (
+            gridParameters != null && isOutside && isChanged ||
+            gridParameters == null && isChanged ||
+            force
+        ) {
+            Log.d(
+                LOG_TAG,
+                "LocalData.update() $xPos, $yPos ($dataArea) from center ${round(boundingBox.centerLongitude * 100) / 100}, ${
+                    round(boundingBox.centerLatitude * 100) / 100
+                } -> ${xPos * dataArea}..${(xPos + 1) * dataArea} ${yPos * dataArea}..${(yPos + 1) * dataArea}, span: ${
+                    round(boundingBox.longitudeSpanWithDateLine * 100) / 100
+                }, ${round(boundingBox.latitudeSpan * 100) / 100} "
+            )
+            this.dataArea = dataArea
+            this.localReference = localReference
+            true
+        } else {
+            false
+        }
     }
+
+    private fun isOutside(boundingBox: BoundingBox, gridParameters: GridParameters): Boolean {
+        return boundingBox.lonWest < gridParameters.longitudeStart ||
+                boundingBox.lonEast > gridParameters.longitudeEnd ||
+                boundingBox.latNorth > gridParameters.latitudeStart ||
+                boundingBox.latSouth < gridParameters.latitudeEnd
+    }
+
+    fun storeResult(gridParameters: GridParameters?) {
+        this.gridParameters = gridParameters
+    }
+}
+
+fun calculateLocalCoordinate(value: Double, dataArea: Int = LOCAL_DATA_AREA): Int {
+    return (value / dataArea).toInt() - if (value < 0) 1 else 0
 }
 
 internal const val LOCAL_REGION = -1

--- a/app/src/main/java/org/blitzortung/android/data/provider/LocalData.kt
+++ b/app/src/main/java/org/blitzortung/android/data/provider/LocalData.kt
@@ -23,7 +23,7 @@ class LocalData @Inject constructor() {
 
     var localReference: LocalReference? = null
     var dataArea: Int = LOCAL_DATA_AREA
-    var gridParameters: GridParameters? = null
+    private var gridParameters: GridParameters? = null
 
     fun updateParameters(parameters: Parameters, location: Location?): Parameters {
         return when (parameters.region) {

--- a/app/src/main/java/org/blitzortung/android/data/provider/standard/JsonRpcData.kt
+++ b/app/src/main/java/org/blitzortung/android/data/provider/standard/JsonRpcData.kt
@@ -19,6 +19,7 @@ class JsonRpcData(
         val countThreshold = parameters.countThreshold
         val region = parameters.region
         val localReference = parameters.localReference
+        val dataArea = parameters.dataArea
 
         return when (region) {
             GLOBAL_REGION -> {
@@ -48,7 +49,8 @@ class JsonRpcData(
                     gridSize,
                     intervalDuration,
                     intervalOffset,
-                    countThreshold
+                    countThreshold,
+                    dataArea,
                 )
             }
 

--- a/app/src/main/java/org/blitzortung/android/map/OwnMapView.kt
+++ b/app/src/main/java/org/blitzortung/android/map/OwnMapView.kt
@@ -18,6 +18,7 @@
 
 package org.blitzortung.android.map
 
+import android.animation.ValueAnimator
 import android.content.Context
 import android.content.DialogInterface
 import android.graphics.Point
@@ -28,11 +29,15 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import androidx.appcompat.app.AlertDialog
+import androidx.core.animation.doOnCancel
+import androidx.core.animation.doOnEnd
 import androidx.core.view.GestureDetectorCompat
 import org.blitzortung.android.app.Main
+import org.blitzortung.android.app.Main.Companion.LOG_TAG
 import org.blitzortung.android.app.R
 import org.blitzortung.android.app.view.PreferenceKey
 import org.blitzortung.android.location.LocationHandler
+import org.osmdroid.views.MapController
 import org.osmdroid.views.MapView
 
 
@@ -101,6 +106,15 @@ class OwnMapView(context: Context) : MapView(context) {
     }
 
     val popup: View by lazy { LayoutInflater.from(context).inflate(R.layout.popup, this, false) }
+
+    private val animatorField = MapController::class.java.getDeclaredField("mCurrentAnimator")
+
+    fun animator(): ValueAnimator? {
+        if (!isAnimating) return null
+
+        animatorField.isAccessible = true
+        return animatorField.get(controller) as ValueAnimator
+    }
 
     companion object {
         const val DEFAULT_ZOOM_SPEED = 500L

--- a/app/src/main/java/org/blitzortung/android/map/OwnMapView.kt
+++ b/app/src/main/java/org/blitzortung/android/map/OwnMapView.kt
@@ -29,11 +29,8 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import androidx.appcompat.app.AlertDialog
-import androidx.core.animation.doOnCancel
-import androidx.core.animation.doOnEnd
 import androidx.core.view.GestureDetectorCompat
 import org.blitzortung.android.app.Main
-import org.blitzortung.android.app.Main.Companion.LOG_TAG
 import org.blitzortung.android.app.R
 import org.blitzortung.android.app.view.PreferenceKey
 import org.blitzortung.android.location.LocationHandler
@@ -113,7 +110,8 @@ class OwnMapView(context: Context) : MapView(context) {
         if (!isAnimating) return null
 
         animatorField.isAccessible = true
-        return animatorField.get(controller) as ValueAnimator
+        val value = animatorField.get(controller)
+        return value?.let { value as ValueAnimator }
     }
 
     companion object {

--- a/app/src/main/java/org/blitzortung/android/util/TimeFormat.kt
+++ b/app/src/main/java/org/blitzortung/android/util/TimeFormat.kt
@@ -37,7 +37,7 @@ object TimeFormat {
 
     fun parseTimeWithMilliseconds(timestampString: String): Long {
         try {
-            return DATE_TIME_MILLISECONDS_FORMATTER.parse(timestampString).time
+            return DATE_TIME_MILLISECONDS_FORMATTER.parse(timestampString)!!.time
         } catch (e: ParseException) {
             throw IllegalArgumentException("Unable to parse millisecond time string '%s'".format(timestampString), e)
         }
@@ -50,7 +50,7 @@ object TimeFormat {
 
     fun parseTime(timestampString: String): Long {
         try {
-            return JSON_DATE_TIME_FORMATTER.parse(timestampString).time
+            return JSON_DATE_TIME_FORMATTER.parse(timestampString)!!.time
         } catch (e: ParseException) {
             throw IllegalArgumentException("Unable to parse time string '%s'".format(timestampString), e)
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@ Polish by Jakub Świątkiewicz (kuba.dex@gmail.com), Agnieszka Cieślak (aga_04@
 Italian by Michele Locati (michele@locati.it)\n
 Russian by Ivan Karev (karev.ivan@gmail.com)\n
     </string>
-    <string name="copyright" translatable="false">© 2011–2024, Andreas Würl</string>
+    <string name="copyright" translatable="false">© 2011–2025, Andreas Würl</string>
     <string name="project_email" translatable="false">blitzortung@tryb.de</string>
     <string name="legend">Legend</string>
     <string name="legend_grid">Grid</string>

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <changelog>
     <release
+        versionName="2.3"
+        versionCode="327">
+        <feature>Dynamic local data retrieval</feature>
+    </release>
+    <release
         versionName="2.2"
         versionCode="293">
         <feature>Time slider replaces buttons</feature>

--- a/app/src/test/java/org/blitzortung/android/alert/handler/AlertDataHandlerTest.kt
+++ b/app/src/test/java/org/blitzortung/android/alert/handler/AlertDataHandlerTest.kt
@@ -67,7 +67,7 @@ class AlertDataHandlerTest {
         strike = strike.copy(timestamp = thresholdTime)
         every { location.distanceTo(any()) } returns 2500f
 
-        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)
+        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)!!
 
         val sector = result.sectorWithClosestStrike
         assertThat(sector).isNotNull
@@ -82,7 +82,7 @@ class AlertDataHandlerTest {
         every { location.distanceTo(any()) } returns 2500f
         every { location.bearingTo(any()) } returns 90f
 
-        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)
+        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)!!
 
         val sector = result.sectorWithClosestStrike
         assertThat(sector).isNotNull
@@ -97,7 +97,7 @@ class AlertDataHandlerTest {
         every { location.distanceTo(any()) } returns 2500f
         every { location.bearingTo(any()) } returns 180f
 
-        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)
+        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)!!
 
         val sector = result.sectorWithClosestStrike
         assertThat(sector).isNotNull
@@ -111,7 +111,7 @@ class AlertDataHandlerTest {
         strike = strike.copy(timestamp = thresholdTime)
         every { location.distanceTo(any()) } returns 5000.1f
 
-        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)
+        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)!!
 
         assertThat(result.sectorWithClosestStrike).isNull()
         assertThat(rangeWithStrike(result)).isNull()
@@ -123,7 +123,7 @@ class AlertDataHandlerTest {
         every { location.distanceTo(any()) } returns 2500.1f
         every { location.bearingTo(any()) } returns -90f
 
-        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)
+        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)!!
 
         assertThat(result.sectorWithClosestStrike).isNull()
         assertSectorAndRange(result, "N", 5f, beforeThresholdTime)
@@ -134,7 +134,7 @@ class AlertDataHandlerTest {
         strike = strike.copy(timestamp = beforeThresholdTime)
         every { location.distanceTo(any()) } returns 5000.1f
 
-        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)
+        val result = alertDataHandler.checkStrikes(Strikes(listOf(strike)), location, parameters, now)!!
 
         assertThat(result.sectorWithClosestStrike).isNull()
         assertThat(rangeWithStrike(result)).isNull()

--- a/app/src/test/java/org/blitzortung/android/data/GridParametersTest.kt
+++ b/app/src/test/java/org/blitzortung/android/data/GridParametersTest.kt
@@ -1,0 +1,61 @@
+package org.blitzortung.android.data
+
+import org.assertj.core.api.Assertions.assertThat
+import org.blitzortung.android.data.beans.GridParameters
+import org.junit.Test
+
+
+class GridParametersTest {
+
+    private val parameters = GridParameters(10.0, 45.0, 0.2, 0.2, 20, 15)
+
+    @Test
+    fun testRectCenter() {
+        assertThat(parameters.rectCenterLongitude).isEqualTo(12.0)
+        assertThat(parameters.rectCenterLatitude).isEqualTo(43.5)
+    }
+
+    @Test
+    fun testElementCenter() {
+        assertThat(parameters.getCenterLongitude(0)).isEqualTo(10.1)
+        assertThat(parameters.getCenterLatitude(0)).isEqualTo(44.9)
+
+        assertThat(parameters.getCenterLongitude(19)).isEqualTo(13.9)
+        assertThat(parameters.getCenterLatitude(19)).isEqualTo(41.1)
+    }
+
+//    @Test
+//    fun testGetRect() {
+//        val screenRect = Rect(10, 20, 30, 40)
+//        val center = GeoPoint(42.5, 12.5)
+//        val projection = Projection(5.0, screenRect, center, 0.0, 0, 0.0, false, false, null, 0, 0)
+//        parameters.getRect(projection)
+//    }
+
+    @Test
+    fun containsWithoutInset() {
+        assertThat(parameters.contains(10.0, 42.0)).isTrue
+        assertThat(parameters.contains(14.0, 42.0)).isTrue
+        assertThat(parameters.contains(14.0, 45.0)).isTrue
+        assertThat(parameters.contains(10.0, 45.0)).isTrue
+        assertThat(parameters.contains(12.0, 43.5)).isTrue
+
+        assertThat(parameters.contains(9.9, 42.0)).isFalse
+        assertThat(parameters.contains(10.0, 41.9)).isFalse
+        assertThat(parameters.contains(14.1, 45.0)).isFalse
+        assertThat(parameters.contains(14.0, 45.1)).isFalse
+    }
+
+    @Test
+    fun containsWithPositiveInset() {
+        assertThat(parameters.contains(10.5, 42.5, 0.5)).isTrue
+        assertThat(parameters.contains(13.5, 42.5, 0.5)).isTrue
+        assertThat(parameters.contains(13.5, 44.5, 0.5)).isTrue
+        assertThat(parameters.contains(10.5, 44.5, 0.5)).isTrue
+
+        assertThat(parameters.contains(10.4, 42.5, 0.5)).isFalse
+        assertThat(parameters.contains(10.5, 42.4, 0.5)).isFalse
+        assertThat(parameters.contains(13.6, 44.5, 0.5)).isFalse
+        assertThat(parameters.contains(13.5, 44.6, 0.5)).isFalse
+    }
+}

--- a/app/src/test/java/org/blitzortung/android/data/MainDataHandlerTest.kt
+++ b/app/src/test/java/org/blitzortung/android/data/MainDataHandlerTest.kt
@@ -1,17 +1,30 @@
 package org.blitzortung.android.data
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.os.Handler
 import io.mockk.MockKAnnotations
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.blitzortung.android.app.view.PreferenceKey
+import org.blitzortung.android.data.MainDataHandler.Companion.REQUEST_STARTED_EVENT
 import org.blitzortung.android.data.cache.DataCache
 import org.blitzortung.android.data.provider.DataProviderFactory
+import org.blitzortung.android.data.provider.DataProviderType
 import org.blitzortung.android.data.provider.LocalData
+import org.blitzortung.android.data.provider.result.DataEvent
+import org.blitzortung.android.data.provider.result.StatusEvent
+import org.blitzortung.android.map.OwnMapView
 import org.blitzortung.android.util.Period
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.osmdroid.events.ScrollEvent
+import org.osmdroid.util.BoundingBox
+import org.osmdroid.views.MapView
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
@@ -19,6 +32,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
 class MainDataHandlerTest {
+
+    private lateinit var preferences: SharedPreferences
 
     @MockK
     private lateinit var dataProviderFactory: DataProviderFactory
@@ -32,6 +47,9 @@ class MainDataHandlerTest {
     @MockK
     private lateinit var period: Period
 
+    private lateinit var receivedEvents: MutableList<DataEvent>;
+
+
     private lateinit var uut: MainDataHandler
 
     @Before
@@ -41,11 +59,81 @@ class MainDataHandlerTest {
         val context = RuntimeEnvironment.getApplication()
         val preferences = context.getSharedPreferences(context.packageName, Context.MODE_PRIVATE)
 
+        this.preferences = preferences
         uut = MainDataHandler(context, dataProviderFactory, preferences, handler, DataCache(), localData, period)
+
+        receivedEvents = mutableListOf<DataEvent>()
+        val eventConsumer: (DataEvent) -> Unit = { event -> receivedEvents.add(event) }
+        uut.requestUpdates(eventConsumer)
     }
 
     @Test
-    fun blabla() {
-        assertThat(uut.isRealtime).isTrue
+    fun updateGridSize() {
+        val result = uut.updateAutoGridSize(5.0)
+
+        assertThat(result).isTrue
+        assertThat(uut.parameters.gridSize).isEqualTo(25000)
+    }
+
+    @Test
+    fun SharedPreferencesChangedForDataSource() {
+        preferences.edit()
+            .putString(PreferenceKey.DATA_SOURCE.toString(), DataProviderType.HTTP.toString())
+            .commit()
+
+        uut.onSharedPreferenceChanged(preferences, PreferenceKey.DATA_SOURCE)
+
+        verify { dataProviderFactory.getDataProviderForType(DataProviderType.HTTP) }
+        assertThat(receivedEvents).contains(REQUEST_STARTED_EVENT)
+    }
+
+    @Test
+    fun SharedPreferencesChangedForGridSize() {
+        preferences.edit()
+            .putString(PreferenceKey.GRID_SIZE.toString(), "5000")
+            .commit()
+
+        uut.onSharedPreferenceChanged(preferences, PreferenceKey.GRID_SIZE)
+
+        assertThat(uut.parameters.gridSize).isEqualTo(5000)
+        assertThat(receivedEvents).contains(REQUEST_STARTED_EVENT)
+    }
+
+    @Test
+    fun tryDataModeRun() {
+        uut.run()
+
+        assertThat(receivedEvents).contains(StatusEvent("0/60"))
+        verify {handler.postDelayed(uut, 1000)}
+    }
+
+    @Test
+    fun reactOnScrollWithinDataArea() {
+        val mapView = mockk<OwnMapView>();
+//        every { mapView.isAnimating } returns false
+        val boundingBox = BoundingBox(45.0, 15.0, 40.0, 10.0)
+        every { mapView.boundingBox } returns boundingBox
+        every { localData.update(boundingBox, false) } returns false
+
+        val event = ScrollEvent(mapView, 100, 100)
+
+        val result = uut.onScroll(event)
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun reactOnScrollLeavingDataArea() {
+        val mapView = mockk<OwnMapView>();
+        every { mapView.isAnimating } returns false
+        val boundingBox = BoundingBox(45.0, 15.0, 40.0, 10.0)
+        every { mapView.boundingBox } returns boundingBox
+        every { localData.update(boundingBox, false) } returns true
+        val event = ScrollEvent(mapView, 100, 100)
+
+        val result = uut.onScroll(event)
+
+        assertThat(result).isTrue
     }
 }
+

--- a/app/src/test/java/org/blitzortung/android/data/MainDataHandlerTest.kt
+++ b/app/src/test/java/org/blitzortung/android/data/MainDataHandlerTest.kt
@@ -171,6 +171,13 @@ class MainDataHandlerTest {
     }
 
     @Test
+    fun onZoomWithoutEvent() {
+        val result = uut.onZoom(null)
+
+        assertThat(result).isFalse
+    }
+
+    @Test
     fun reactOnZoomWithinDataArea() {
         val mapView = mockk<OwnMapView>();
         every { mapView.isAnimating } returns false

--- a/app/src/test/java/org/blitzortung/android/data/MainDataHandlerTest.kt
+++ b/app/src/test/java/org/blitzortung/android/data/MainDataHandlerTest.kt
@@ -23,6 +23,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.osmdroid.events.ScrollEvent
+import org.osmdroid.events.ZoomEvent
 import org.osmdroid.util.BoundingBox
 import org.osmdroid.views.MapView
 import org.robolectric.RobolectricTestRunner
@@ -108,6 +109,13 @@ class MainDataHandlerTest {
     }
 
     @Test
+    fun onScrollWithoutEvent() {
+        val result = uut.onScroll(null)
+
+        assertThat(result).isFalse
+    }
+
+    @Test
     fun reactOnScrollWithinDataArea() {
         val mapView = mockk<OwnMapView>();
 //        every { mapView.isAnimating } returns false
@@ -132,6 +140,48 @@ class MainDataHandlerTest {
         val event = ScrollEvent(mapView, 100, 100)
 
         val result = uut.onScroll(event)
+
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun reactOnZoomWithinDataArea() {
+        val mapView = mockk<OwnMapView>();
+        every { mapView.isAnimating } returns false
+        val boundingBox = BoundingBox(45.0, 15.0, 40.0, 10.0)
+        every { mapView.boundingBox } returns boundingBox
+        every { localData.update(boundingBox, false) } returns false
+        val event = ZoomEvent(mapView, 6.0)
+
+        val result = uut.onZoom(event)
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun reactOnZoomlLeavingDataArea() {
+        val mapView = mockk<OwnMapView>();
+        every { mapView.isAnimating } returns false
+        val boundingBox = BoundingBox(45.0, 15.0, 40.0, 10.0)
+        every { mapView.boundingBox } returns boundingBox
+        every { localData.update(boundingBox, false) } returns true
+        val event = ZoomEvent(mapView, 6.0)
+
+        val result = uut.onZoom(event)
+
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun reactOnZoomlUpdateGridSize() {
+        val mapView = mockk<OwnMapView>();
+        every { mapView.isAnimating } returns false
+        val boundingBox = BoundingBox(45.0, 15.0, 40.0, 10.0)
+        every { mapView.boundingBox } returns boundingBox
+        every { localData.update(boundingBox, false) } returns false
+        val event = ZoomEvent(mapView, 8.0)
+
+        val result = uut.onZoom(event)
 
         assertThat(result).isTrue
     }

--- a/app/src/test/java/org/blitzortung/android/data/MainDataHandlerTest.kt
+++ b/app/src/test/java/org/blitzortung/android/data/MainDataHandlerTest.kt
@@ -1,0 +1,51 @@
+package org.blitzortung.android.data
+
+import android.content.Context
+import android.os.Handler
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import org.assertj.core.api.Assertions.assertThat
+import org.blitzortung.android.data.cache.DataCache
+import org.blitzortung.android.data.provider.DataProviderFactory
+import org.blitzortung.android.data.provider.LocalData
+import org.blitzortung.android.util.Period
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class MainDataHandlerTest {
+
+    @MockK
+    private lateinit var dataProviderFactory: DataProviderFactory
+
+    @MockK
+    private lateinit var handler: Handler
+
+    @MockK
+    private lateinit var localData: LocalData
+
+    @MockK
+    private lateinit var period: Period
+
+    private lateinit var uut: MainDataHandler
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        val context = RuntimeEnvironment.getApplication()
+        val preferences = context.getSharedPreferences(context.packageName, Context.MODE_PRIVATE)
+
+        uut = MainDataHandler(context, dataProviderFactory, preferences, handler, DataCache(), localData, period)
+    }
+
+    @Test
+    fun blabla() {
+        assertThat(uut.isRealtime).isTrue
+    }
+}

--- a/app/src/test/java/org/blitzortung/android/data/provider/LocalDataTest.kt
+++ b/app/src/test/java/org/blitzortung/android/data/provider/LocalDataTest.kt
@@ -4,6 +4,7 @@ import android.location.Location
 import org.assertj.core.api.Assertions.assertThat
 import org.blitzortung.android.data.LocalReference
 import org.blitzortung.android.data.Parameters
+import org.blitzortung.android.data.beans.GridParameters
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -86,6 +87,46 @@ class LocalDataTest {
         assertThat(result).isTrue
         assertThat(uut.dataArea).isEqualTo(5)
         assertThat(uut.localReference).isEqualTo(LocalReference(2, 9))
+    }
+
+    @Test
+    fun noUpdateLocalDataOnGridInside() {
+        val boundingBox = BoundingBox(46.0, 11.0, 45.0, 10.0)
+        uut.update(boundingBox)
+
+        uut.storeResult(GridParameters(10.0, 46.0, 0.2, 0.2, 5, 5))
+        val result = uut.update(boundingBox)
+
+        assertThat(result).isFalse
+        assertThat(uut.dataArea).isEqualTo(5)
+        assertThat(uut.localReference).isEqualTo(LocalReference(2, 9))
+    }
+
+    @Test
+    fun noUpdateLocalDataOnGridOutsideWithoutUpdatedParameters() {
+        val boundingBox = BoundingBox(46.0, 11.0, 45.0, 10.0)
+        uut.update(boundingBox)
+
+        uut.storeResult(GridParameters(10.0, 46.0, 0.2, 0.2, 5, 3))
+        val result = uut.update(boundingBox)
+
+        assertThat(result).isFalse
+        assertThat(uut.dataArea).isEqualTo(5)
+        assertThat(uut.localReference).isEqualTo(LocalReference(2, 9))
+    }
+
+    @Test
+    fun updateLocalDataOnGridOutsideWithUpdatedParameters() {
+        val boundingBox1 = BoundingBox(46.0, 11.0, 45.0, 10.0)
+        uut.update(boundingBox1)
+
+        uut.storeResult(GridParameters(10.0, 46.0, 0.2, 0.2, 5, 5))
+        val boundingBox2 = BoundingBox(55.0, 11.0, 45.0, 10.0)
+        val result = uut.update(boundingBox2)
+
+        assertThat(result).isTrue
+        assertThat(uut.dataArea).isEqualTo(5)
+        assertThat(uut.localReference).isEqualTo(LocalReference(2, 10))
     }
 
     @Test

--- a/app/src/test/java/org/blitzortung/android/data/provider/LocalDataTest.kt
+++ b/app/src/test/java/org/blitzortung/android/data/provider/LocalDataTest.kt
@@ -2,10 +2,12 @@ package org.blitzortung.android.data.provider
 
 import android.location.Location
 import org.assertj.core.api.Assertions.assertThat
+import org.blitzortung.android.data.LocalReference
 import org.blitzortung.android.data.Parameters
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.osmdroid.util.BoundingBox
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -74,6 +76,81 @@ class LocalDataTest {
 
         assertThat(result.localReference).isNull()
         assertThat(result.region).isEqualTo(GLOBAL_REGION)
+    }
+
+    @Test
+    fun updateLocalData() {
+        val boundingBox = BoundingBox(46.0, 11.0, 45.0, 10.0)
+        val result = uut.update(boundingBox)
+
+        assertThat(result).isTrue
+        assertThat(uut.dataArea).isEqualTo(5)
+        assertThat(uut.localReference).isEqualTo(LocalReference(2, 9))
+    }
+
+    @Test
+    fun noUpdateOfLocalDataForSmallMovement() {
+        val boundingBox1 = BoundingBox(46.0, 11.0, 45.0, 10.0)
+        uut.update(boundingBox1)
+
+        val boundingBox2 = BoundingBox(50.0, 15.0, 49.0, 14.0)
+        val result = uut.update(boundingBox2)
+
+        assertThat(result).isFalse
+        assertThat(uut.dataArea).isEqualTo(5)
+        assertThat(uut.localReference).isEqualTo(LocalReference(2, 9))
+    }
+
+    @Test
+    fun forcedUpdateOfLocalData() {
+        val boundingBox1 = BoundingBox(46.0, 11.0, 45.0, 10.0)
+        uut.update(boundingBox1)
+
+        val boundingBox2 = BoundingBox(50.0, 15.0, 49.0, 14.0)
+        val result = uut.update(boundingBox2, force = true)
+
+        assertThat(result).isTrue
+        assertThat(uut.dataArea).isEqualTo(5)
+        assertThat(uut.localReference).isEqualTo(LocalReference(2, 9))
+    }
+
+    @Test
+    fun updateOfLocalDataForMovementExceedingTheDataArea() {
+        val boundingBox1 = BoundingBox(46.0, 11.0, 45.0, 10.0)
+        uut.update(boundingBox1)
+
+        val boundingBox2 = BoundingBox(51.0, 11.0, 50.0, 10.0)
+        val result = uut.update(boundingBox2)
+
+        assertThat(result).isTrue
+        assertThat(uut.dataArea).isEqualTo(5)
+        assertThat(uut.localReference).isEqualTo(LocalReference(2, 10))
+    }
+
+    @Test
+    fun noUpdateOfLocalDataOnZoomWithinArea() {
+        val boundingBox1 = BoundingBox(45.5, 10.5, 44.5, 9.5)
+        uut.update(boundingBox1)
+
+        val boundingBox2 = BoundingBox(50.0, 15.0, 40.0, 5.0)
+        val result = uut.update(boundingBox2)
+
+        assertThat(result).isFalse
+        assertThat(uut.dataArea).isEqualTo(5)
+        assertThat(uut.localReference).isEqualTo(LocalReference(2, 9))
+    }
+
+    @Test
+    fun updateOfLocalDataOnZoomOutsiedArea() {
+        val boundingBox1 = BoundingBox(45.5, 10.5, 44.5, 9.5)
+        uut.update(boundingBox1)
+
+        val boundingBox2 = BoundingBox(51.0, 15.0, 40.0, 5.0)
+        val result = uut.update(boundingBox2)
+
+        assertThat(result).isTrue
+        assertThat(uut.dataArea).isEqualTo(6)
+        assertThat(uut.localReference).isEqualTo(LocalReference(1, 7))
     }
 
     fun createLocation(x: Double, y: Double): Location {

--- a/app/src/test/java/org/blitzortung/android/data/provider/standard/JsonRpcDataProviderTest.kt
+++ b/app/src/test/java/org/blitzortung/android/data/provider/standard/JsonRpcDataProviderTest.kt
@@ -124,7 +124,8 @@ class JsonRpcDataProviderTest {
                 parameters.gridSize,
                 parameters.intervalDuration,
                 parameters.intervalOffset,
-                parameters.countThreshold
+                parameters.countThreshold,
+                parameters.dataArea,
             )
         } returns JsonRpcResponse(response)
 

--- a/app/src/test/java/org/blitzortung/android/map/overlay/color/StrikeColorHandlerTest.kt
+++ b/app/src/test/java/org/blitzortung/android/map/overlay/color/StrikeColorHandlerTest.kt
@@ -1,6 +1,7 @@
 package org.blitzortung.android.map.overlay.color
 
 import android.content.Context
+import io.mockk.MockKAnnotations
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -17,6 +18,8 @@ class StrikeColorHandlerTest {
 
     @Before
     fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
         val context = RuntimeEnvironment.getApplication()
         val preferences = context.getSharedPreferences(context.packageName, Context.MODE_PRIVATE)
 

--- a/app/src/test/java/org/blitzortung/android/map/overlay/color/StrikeColorHandlerTest.kt
+++ b/app/src/test/java/org/blitzortung/android/map/overlay/color/StrikeColorHandlerTest.kt
@@ -1,7 +1,6 @@
 package org.blitzortung.android.map.overlay.color
 
 import android.content.Context
-import io.mockk.MockKAnnotations
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -18,8 +17,6 @@ class StrikeColorHandlerTest {
 
     @Before
     fun setUp() {
-        MockKAnnotations.init(this, relaxed = true)
-
         val context = RuntimeEnvironment.getApplication()
         val preferences = context.getSharedPreferences(context.packageName, Context.MODE_PRIVATE)
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.7.3' apply false
-    id 'com.android.library' version '8.7.3' apply false
+    id 'com.android.application' version '8.8.0' apply false
+    id 'com.android.library' version '8.8.0' apply false
     id 'org.jetbrains.kotlin.android' version '2.0.20' apply false
     id "org.sonarqube" version "5.1.0.4882"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip


### PR DESCRIPTION
In order to save bandwidth and improve speed dynamically switch to local data mode for detail zoom levels when using global data mode. The grid sizes 10 and 5 km will be only accessable from local data queries.